### PR TITLE
[FD] Use a recent version of frontend assets

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -79,7 +79,7 @@ google-analytics {
 }
 
 assets {
-  version = "2.149.0"
+  version = "2.241.0"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
The version in init-service (used to create this frontend) is hard coded and therefore becomes out of date, see https://github.com/hmrc/init-service/issues/26.