### PR TITLE
[FD] Use keystore for transient storage instead of GET parameters and flash scope

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/GuiceModule.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/GuiceModule.scala
@@ -21,16 +21,20 @@ import javax.inject.Provider
 
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
-import uk.gov.hmrc.agentsubscriptionfrontend.config.{AppConfig, FrontendAppConfig, FrontendAuthConnector, WSHttp}
+import uk.gov.hmrc.agentsubscriptionfrontend.config._
+import uk.gov.hmrc.agentsubscriptionfrontend.service.SessionStoreService
+import uk.gov.hmrc.http.cache.client.SessionCache
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.http.HttpGet
 
-class GuiceModule extends AbstractModule with ServicesConfig{
+class GuiceModule extends AbstractModule with ServicesConfig {
   override def configure(): Unit = {
     bind(classOf[HttpGet]).toInstance(WSHttp)
     bind(classOf[AppConfig]).to(classOf[FrontendAppConfig])
     bind(classOf[AuthConnector]).to(classOf[FrontendAuthConnector])
+    bind(classOf[SessionCache]).toInstance(AgentSubscriptionSessionCache)
+    bind(classOf[SessionStoreService])
     bindBaseUrl("agent-subscription")
   }
 

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/config/frontendWiring.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/config/frontendWiring.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentsubscriptionfrontend.config
 
 import javax.inject.Singleton
 
+import uk.gov.hmrc.http.cache.client.SessionCache
 import uk.gov.hmrc.play.audit.http.config.LoadAuditingConfig
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector => Auditing}
 import uk.gov.hmrc.play.config.{AppName, RunMode, ServicesConfig}
@@ -36,4 +37,11 @@ object WSHttp extends WSGet with WSPut with WSPost with WSDelete with AppName wi
 class FrontendAuthConnector extends AuthConnector with ServicesConfig {
   lazy val serviceUrl = baseUrl("auth")
   lazy val http = WSHttp
+}
+
+object AgentSubscriptionSessionCache extends SessionCache with AppName with ServicesConfig {
+  override lazy val http = WSHttp
+  override lazy val defaultSource = appName
+  override lazy val baseUri = baseUrl("cachable.session-cache")
+  override lazy val domain = getConfString("cachable.session-cache.domain", throw new RuntimeException(s"Could not find config 'cachable.session-cache.domain'"))
 }

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyController.scala
@@ -115,7 +115,7 @@ class CheckAgencyController @Inject()
             utr = knownFactsResult.utr,
             nextPageUrl = lookupNextPageUrl(knownFactsResult.isSubscribedToAgentServices)))
         }.getOrElse {
-          showSessionDataMissing()
+          sessionMissingRedirect()
         })
   }
 

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SessionDataMissing.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SessionDataMissing.scala
@@ -22,7 +22,7 @@ import play.api.mvc.{Result, Results}
 trait SessionDataMissing {
   this: Results =>
 
-  def showSessionDataMissing(): Result = {
+  def sessionMissingRedirect(): Result = {
     Logger.warn("No KnownFactsResult in session store, redirecting back to check-agency-status")
     Redirect(routes.CheckAgencyController.showCheckAgencyStatus())
   }

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SessionDataMissing.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SessionDataMissing.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscriptionfrontend.controllers
+
+import play.api.Logger
+import play.api.mvc.{Result, Results}
+
+trait SessionDataMissing {
+  this: Results =>
+
+  def showSessionDataMissing(): Result = {
+    Logger.warn("No KnownFactsResult in session store, redirecting back to check-agency-status")
+    Redirect(routes.CheckAgencyController.showCheckAgencyStatus())
+  }
+}

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
@@ -70,7 +70,7 @@ class SubscriptionController @Inject()
       sessionStoreService.fetchKnownFactsResult.map(_.map { knownFactsResult =>
         Ok(html.subscription_details(subscriptionDetails.fill(SubscriptionDetails(knownFactsResult.utr, knownFactsResult.postcode, null, null, null, null, null, None, null))))
       }.getOrElse {
-        showSessionDataMissing()
+        sessionMissingRedirect()
       })
     }
 

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
@@ -24,7 +24,7 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{AnyContent, _}
 import uk.gov.hmrc.agentsubscriptionfrontend.auth.AuthActions
 import uk.gov.hmrc.agentsubscriptionfrontend.config.AppConfig
-import uk.gov.hmrc.agentsubscriptionfrontend.service.SubscriptionService
+import uk.gov.hmrc.agentsubscriptionfrontend.service.{SessionStoreService, SubscriptionService}
 import uk.gov.hmrc.agentsubscriptionfrontend.views.html
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.frontend.controller.FrontendController
@@ -45,10 +45,11 @@ case class SubscriptionDetails(utr: String,
 class SubscriptionController @Inject()
   (override val messagesApi: MessagesApi,
    override val authConnector: AuthConnector,
-   subscriptionService: SubscriptionService
+   subscriptionService: SubscriptionService,
+   sessionStoreService: SessionStoreService
   )
   (implicit appConfig: AppConfig)
-  extends FrontendController with I18nSupport with AuthActions {
+  extends FrontendController with I18nSupport with AuthActions with SessionDataMissing {
 
   private val subscriptionDetails = Form[SubscriptionDetails](
     mapping(
@@ -64,10 +65,14 @@ class SubscriptionController @Inject()
     )(SubscriptionDetails.apply)(SubscriptionDetails.unapply)
   )
 
-  def showSubscriptionDetails(utr: String, knownFactsPostcode: String): Action[AnyContent] =
-    AuthorisedWithSubscribingAgent { implicit authContext => implicit request =>
-      Ok(html.subscription_details(subscriptionDetails.fill(SubscriptionDetails(utr, knownFactsPostcode, null, null, null, null, null, None, null))))
-  }
+  val showSubscriptionDetails: Action[AnyContent] =
+    AuthorisedWithSubscribingAgentAsync { implicit authContext => implicit request =>
+      sessionStoreService.fetchKnownFactsResult.map(_.map { knownFactsResult =>
+        Ok(html.subscription_details(subscriptionDetails.fill(SubscriptionDetails(knownFactsResult.utr, knownFactsResult.postcode, null, null, null, null, null, None, null))))
+      }.getOrElse {
+        showSessionDataMissing()
+      })
+    }
 
   val submitSubscriptionDetails: Action[AnyContent] = AuthorisedWithSubscribingAgentAsync {
     implicit authContext =>
@@ -76,11 +81,15 @@ class SubscriptionController @Inject()
           formWithErrors => {
             Future successful Ok(html.subscription_details(formWithErrors))
           },
-          form => subscriptionService.subscribeAgencyToMtd(form) map {
-            case Right(_) => Redirect(routes.SubscriptionController.showSubscriptionComplete())
-            case Left(CONFLICT) => Redirect(routes.CheckAgencyController.showAlreadySubscribed())
-            case Left(FORBIDDEN) => Redirect(routes.SubscriptionController.showSubscriptionFailed())
-            case Left(error) => InternalServerError(s"Unknown error code from agent-subscription $error")
+          form => subscriptionService.subscribeAgencyToMtd(form) flatMap { subscriptionResponse =>
+            sessionStoreService.remove() map { _ =>
+              subscriptionResponse match {
+                case Right(_) => Redirect(routes.SubscriptionController.showSubscriptionComplete())
+                case Left(CONFLICT) => Redirect(routes.CheckAgencyController.showAlreadySubscribed())
+                case Left(FORBIDDEN) => Redirect(routes.SubscriptionController.showSubscriptionFailed())
+                case Left(error) => InternalServerError(s"Unknown error code from agent-subscription $error")
+              }
+            }
           })
   }
 

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/models/KnownFactsResult.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/models/KnownFactsResult.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscriptionfrontend.models
+
+import play.api.libs.json.Json
+
+case class KnownFactsResult(utr: String, postcode: String, organisationName: String, isSubscribedToAgentServices: Boolean)
+
+object KnownFactsResult {
+  implicit val format = Json.format[KnownFactsResult]
+}

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/service/SessionStoreService.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/service/SessionStoreService.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscriptionfrontend.service
+
+import javax.inject.{Inject, Singleton}
+
+import uk.gov.hmrc.agentsubscriptionfrontend.models.KnownFactsResult
+import uk.gov.hmrc.http.cache.client.SessionCache
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SessionStoreService @Inject() (sessionCache: SessionCache) {
+
+  def fetchKnownFactsResult(implicit hc: HeaderCarrier): Future[Option[KnownFactsResult]] =
+    sessionCache.fetchAndGetEntry[KnownFactsResult]("knownFactsResult")
+
+  def cacheKnownFactsResult(knownFactsResult: KnownFactsResult)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
+    sessionCache.cache("knownFactsResult", knownFactsResult).map(_ => ())
+
+  def remove()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
+    sessionCache.remove().map(_ => ())
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,7 +11,7 @@ GET     /confirm-your-agency            uk.gov.hmrc.agentsubscriptionfrontend.co
 GET     /already-subscribed             uk.gov.hmrc.agentsubscriptionfrontend.controllers.CheckAgencyController.showAlreadySubscribed
 GET     /has-other-enrolments           uk.gov.hmrc.agentsubscriptionfrontend.controllers.CheckAgencyController.showHasOtherEnrolments
 
-GET     /subscription-details           uk.gov.hmrc.agentsubscriptionfrontend.controllers.SubscriptionController.showSubscriptionDetails(utr: String, knownFactsPostcode: String)
+GET     /subscription-details           uk.gov.hmrc.agentsubscriptionfrontend.controllers.SubscriptionController.showSubscriptionDetails
 POST    /subscription-details           uk.gov.hmrc.agentsubscriptionfrontend.controllers.SubscriptionController.submitSubscriptionDetails
 
 GET    /subscription-complete           uk.gov.hmrc.agentsubscriptionfrontend.controllers.SubscriptionController.showSubscriptionComplete

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,12 @@ microservice.services {
     host=localhost
     port=9436
   }
+
+  cachable.session-cache {
+    host = localhost
+    port = 8400
+    domain = keystore
+  }
 }
 
 metrics {

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BaseControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BaseControllerISpec.scala
@@ -1,24 +1,43 @@
 package uk.gov.hmrc.agentsubscriptionfrontend.controllers
 
+import com.google.inject.AbstractModule
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentType, _}
+import uk.gov.hmrc.agentsubscriptionfrontend.service.SessionStoreService
 import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AuthStub
 import uk.gov.hmrc.agentsubscriptionfrontend.support.SampleUsers._
-import uk.gov.hmrc.agentsubscriptionfrontend.support.{EndpointBehaviours, WireMockSupport}
+import uk.gov.hmrc.agentsubscriptionfrontend.support.{EndpointBehaviours, TestSessionStoreService, WireMockSupport}
 import uk.gov.hmrc.play.test.UnitSpec
 
 abstract class BaseControllerISpec extends UnitSpec with OneAppPerSuite with WireMockSupport with EndpointBehaviours {
 
-  override implicit lazy val app: Application = new GuiceApplicationBuilder()
-    .configure(
-      "microservice.services.auth.port" -> wireMockPort,
-      "microservice.services.agent-subscription.port" -> wireMockPort
-    )
-    .build()
+  override implicit lazy val app: Application = appBuilder.build()
+
+  protected def appBuilder: GuiceApplicationBuilder = {
+    new GuiceApplicationBuilder()
+      .configure(
+        "microservice.services.auth.port" -> wireMockPort,
+        "microservice.services.agent-subscription.port" -> wireMockPort
+      )
+      .overrides(new TestGuiceModule)
+  }
+
+  protected lazy val sessionStoreService = new TestSessionStoreService
+
+  private class TestGuiceModule extends AbstractModule {
+    override def configure(): Unit = {
+      bind(classOf[SessionStoreService]).toInstance(sessionStoreService)
+    }
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    sessionStoreService.reset()
+  }
 
   protected implicit val materializer = app.materializer
 

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SessionDataMissingSpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SessionDataMissingSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscriptionfrontend.controllers
+
+import akka.util.Timeout
+import play.api.mvc.Result
+import play.api.test.Helpers.redirectLocation
+import uk.gov.hmrc.play.test.UnitSpec
+
+trait SessionDataMissingSpec {
+  this: UnitSpec =>
+
+  def resultShouldBeSessionDataMissing(result: Result)(implicit timeout: Timeout): Unit = {
+    status(result) shouldBe 303
+    redirectLocation(result).get shouldBe routes.CheckAgencyController.showCheckAgencyStatus().url
+  }
+}

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/support/TestSessionStoreService.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/support/TestSessionStoreService.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscriptionfrontend.support
+
+import uk.gov.hmrc.agentsubscriptionfrontend.models.KnownFactsResult
+import uk.gov.hmrc.agentsubscriptionfrontend.service.SessionStoreService
+import uk.gov.hmrc.play.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TestSessionStoreService extends SessionStoreService(null) {
+  var knownFactsResult: Option[KnownFactsResult] = None
+  var removeCalled: Boolean = false
+
+  def reset(): Unit = {
+    knownFactsResult = None
+    removeCalled = false
+  }
+
+  override def fetchKnownFactsResult(implicit hc: HeaderCarrier): Future[Option[KnownFactsResult]] = Future successful knownFactsResult
+
+  override def cacheKnownFactsResult(knownFactsResult: KnownFactsResult)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
+    Future {
+      this.knownFactsResult = Some(knownFactsResult)
+    }
+
+  override def remove()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Unit] =
+    Future {
+      reset()
+      removeCalled = true
+    }
+}

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -17,7 +17,8 @@ object FrontendBuild extends Build with MicroService {
     "uk.gov.hmrc" %% "logback-json-logger" % "3.1.0",
     "uk.gov.hmrc" %% "govuk-template" % "5.0.0",
     "uk.gov.hmrc" %% "play-health" % "2.0.0",
-    "uk.gov.hmrc" %% "play-ui" % "5.4.0"
+    "uk.gov.hmrc" %% "play-ui" % "5.4.0",
+    "uk.gov.hmrc" %% "http-caching-client" % "6.1.0"
   )
 
   def test(scope: String = "test") = Seq(

--- a/test/uk/gov/hmrc/agentsubscriptionfrontend/auth/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/agentsubscriptionfrontend/auth/AuthActionSpec.scala
@@ -23,6 +23,7 @@ import play.api.mvc._
 import uk.gov.hmrc.agentsubscriptionfrontend.config.AppConfig
 import uk.gov.hmrc.agentsubscriptionfrontend.connectors.AgentSubscriptionConnector
 import uk.gov.hmrc.agentsubscriptionfrontend.controllers.CheckAgencyController
+import uk.gov.hmrc.agentsubscriptionfrontend.service.SessionStoreService
 import uk.gov.hmrc.agentsubscriptionfrontend.support.{TestAppConfig, TestMessagesApi}
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
@@ -41,11 +42,12 @@ class AuthActionSpec extends UnitSpec with MockitoSugar {
 
       val authConnector = mock[AuthConnector]
       val agentSubscriptionConnector = mock[AgentSubscriptionConnector]
+      val sessionStoreService = mock[SessionStoreService]
       val failure = Upstream5xxResponse("failure in auth", 500, 500)
       when(authConnector.currentAuthority(any[HeaderCarrier])).thenReturn(Future successful Some(authority))
       when(authConnector.getUserDetails(any[AuthContext])(any[HeaderCarrier], any[HttpReads[HttpResponse]])).thenReturn(Future failed failure)
 
-      val controller = new CheckAgencyController(TestMessagesApi.testMessagesApi, authConnector, agentSubscriptionConnector)
+      val controller = new CheckAgencyController(TestMessagesApi.testMessagesApi, authConnector, agentSubscriptionConnector, sessionStoreService)
 
       intercept[Upstream5xxResponse] {
         val eventualResult: Future[Result] = controller.showCheckAgencyStatus(mockRequestWithMockAuthSession)

--- a/test/uk/gov/hmrc/agentsubscriptionfrontend/service/SessionStoreServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentsubscriptionfrontend/service/SessionStoreServiceSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscriptionfrontend.service
+
+import play.api.libs.json.{JsValue, Reads, Writes}
+import uk.gov.hmrc.agentsubscriptionfrontend.models.KnownFactsResult
+import uk.gov.hmrc.http.cache.client.{CacheMap, NoSessionException, SessionCache}
+import uk.gov.hmrc.play.http.logging.SessionId
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SessionStoreServiceSpec extends UnitSpec {
+
+  private implicit val hc = HeaderCarrier(sessionId = Some(SessionId("sessionId123456")))
+
+  "SessionStoreService" should {
+    "store known facts" in {
+      val store = new SessionStoreService(new TestSessionCache())
+
+      val knownFactsResult = KnownFactsResult("9876543210", "AA11AA", "Test organisation name", isSubscribedToAgentServices = true)
+
+      await(store.cacheKnownFactsResult(knownFactsResult))
+
+      await(store.fetchKnownFactsResult) shouldBe Some(knownFactsResult)
+    }
+
+    "return None when no known facts have been stored" in {
+      val store = new SessionStoreService(new TestSessionCache())
+
+      await(store.fetchKnownFactsResult) shouldBe None
+    }
+
+    "remove the underlying storage for the current session when remove is called" in {
+      val store = new SessionStoreService(new TestSessionCache())
+
+      val knownFactsResult = KnownFactsResult("9876543210", "AA11AA", "Test organisation name", isSubscribedToAgentServices = true)
+
+      await(store.cacheKnownFactsResult(knownFactsResult))
+
+      await(store.remove())
+
+      await(store.fetchKnownFactsResult) shouldBe None
+    }
+  }
+
+}
+
+class TestSessionCache extends SessionCache {
+  override def defaultSource = ???
+  override def baseUri = ???
+  override def domain = ???
+  override def http = ???
+
+  private val store = mutable.Map[String, JsValue]()
+
+  private val noSession = Future.failed[String](NoSessionException)
+
+  private def testCacheId(implicit hc: HeaderCarrier): Future[String] =
+    hc.sessionId.fold(noSession)(c => Future.successful(c.value))
+
+  override def cache[A](formId: String, body: A)(implicit wts: Writes[A], hc: HeaderCarrier): Future[CacheMap] =
+    testCacheId.map { c =>
+      store.put(formId, wts.writes(body))
+      CacheMap(c, store.toMap)
+    }
+
+  override def fetch()(implicit hc: HeaderCarrier): Future[Option[CacheMap]] =
+    testCacheId.map(c => Some(CacheMap(c, store.toMap)))
+
+  override def fetchAndGetEntry[T](key: String)(implicit hc: HeaderCarrier, rds: Reads[T]): Future[Option[T]] =
+    Future {
+      store.get(key).flatMap(jsValue => rds.reads(jsValue).asOpt)
+    }
+
+  override def remove()(implicit hc: HeaderCarrier): Future[HttpResponse] =
+    Future {
+      store.clear()
+      null
+    }
+}


### PR DESCRIPTION
Using GET parameters for UTR & Postcode is insecure because it results in them being included in web server logs.