### PR TITLE
[FD] Prevent ServiceConfig from using play Application in GuiceModule

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/GuiceModule.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/GuiceModule.scala
@@ -21,6 +21,8 @@ import javax.inject.Provider
 
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
+import play.api.Mode.Mode
+import play.api.{Configuration, Environment}
 import uk.gov.hmrc.agentsubscriptionfrontend.config._
 import uk.gov.hmrc.agentsubscriptionfrontend.service.SessionStoreService
 import uk.gov.hmrc.http.cache.client.SessionCache
@@ -28,7 +30,11 @@ import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.http.HttpGet
 
-class GuiceModule extends AbstractModule with ServicesConfig {
+class GuiceModule(environment: Environment, configuration: Configuration) extends AbstractModule with ServicesConfig {
+
+  override protected lazy val mode: Mode = environment.mode
+  override protected lazy val runModeConfiguration: Configuration = configuration
+
   override def configure(): Unit = {
     bind(classOf[HttpGet]).toInstance(WSHttp)
     bind(classOf[AppConfig]).to(classOf[FrontendAppConfig])


### PR DESCRIPTION
This guards against errors during startup when classes that have configuration injected are explicitly bound - see https://github.com/hmrc/agent-subscription/commit/7aa575808e544665a022091b979c8d7dfd7bc620