### PR TITLE
[FD][APB-734] Make Government Gateway URL configurable

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/config/frontendAppConfig.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/config/frontendAppConfig.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.agentsubscriptionfrontend.config
 
 import javax.inject.Singleton
 
-import play.api.Logger
 import play.api.Play.{configuration, current}
 import uk.gov.hmrc.agentsubscriptionfrontend.controllers.routes
 import uk.gov.hmrc.play.config.ServicesConfig
@@ -30,6 +29,7 @@ trait AppConfig {
   val reportAProblemNonJSUrl: String
   val betaFeedbackUrl: String
   val betaFeedbackUnauthenticatedUrl: String
+  val governmentGatewayUrl: String
 }
 
 trait StrictConfig{
@@ -64,4 +64,5 @@ class FrontendAppConfig extends AppConfig with StrictConfig with ServicesConfig 
   override lazy val betaFeedbackUnauthenticatedUrl = s"$contactHost/contact/beta-feedback-unauthenticated?service=$contactFormServiceIdentifier"
   override lazy val reportAProblemPartialUrl = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
   override lazy val reportAProblemNonJSUrl = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
+  override lazy val governmentGatewayUrl: String = loadConfig("government-gateway.url")
 }

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/views/has_other_enrolments.scala.html
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/views/has_other_enrolments.scala.html
@@ -5,6 +5,6 @@
   <h1>Create your new account ID and password</h1>
   <p>You'll do this through the Government Gateway.</p>
   <p>
-    <a class="button" href="http://www.gateway.gov.uk/" role="button">Continue</a>
+    <a class="button" href="@appConfig.governmentGatewayUrl" role="button">Continue</a>
   </p>
 }

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/views/non_agent_next_steps.scala.html
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/views/non_agent_next_steps.scala.html
@@ -10,6 +10,6 @@
   </ul>
   <p>Registering should take around 5 minutes.</p>
   <p>
-    <a class="button" href="http://www.gateway.gov.uk/" role="button">Register now</a>
+    <a class="button" href="@appConfig.governmentGatewayUrl" role="button">Register now</a>
   </p>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -105,3 +105,5 @@ authentication {
   government-gateway.sign-in.base-url = "http://localhost:9025"
   government-gateway.sign-out.base-url = "http://localhost:9025"
 }
+
+government-gateway.url = "http://www.ref.gateway.gov.uk/"

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/StartControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/StartControllerISpec.scala
@@ -1,5 +1,6 @@
 package uk.gov.hmrc.agentsubscriptionfrontend.controllers
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentType, _}
 import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AuthStub
@@ -7,6 +8,10 @@ import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AuthStub
 class StartControllerISpec extends BaseControllerISpec {
 
   private lazy val controller: StartController = app.injector.instanceOf[StartController]
+  private lazy val configuredGovernmentGatewayUrl = "http://configured-government-gateway.gov.uk/"
+
+  override protected def appBuilder: GuiceApplicationBuilder = super.appBuilder
+    .configure("government-gateway.url" -> configuredGovernmentGatewayUrl)
 
   "context root" should {
     "redirect to start page" in {
@@ -45,6 +50,13 @@ class StartControllerISpec extends BaseControllerISpec {
       contentType(result) shouldBe Some("text/html")
       charset(result) shouldBe Some("utf-8")
       bodyOf(result) should include("This isn't an agent account")
+    }
+
+    "allow the government gateway URL to be configured" in {
+      val result = await(controller.showNonAgentNextSteps(authenticatedRequest()))
+
+      status(result) shouldBe 200
+      bodyOf(result) should include(configuredGovernmentGatewayUrl)
     }
 
     "redirect to the company-auth-frontend sign-in page if the current user is not logged in" in {

--- a/test/uk/gov/hmrc/agentsubscriptionfrontend/support/TestAppConfig.scala
+++ b/test/uk/gov/hmrc/agentsubscriptionfrontend/support/TestAppConfig.scala
@@ -29,4 +29,5 @@ object TestAppConfig extends AppConfig {
   override lazy val reportAProblemNonJSUrl = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
   override lazy val betaFeedbackUrl = s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier"
   override lazy val betaFeedbackUnauthenticatedUrl = s"$contactHost/contact/beta-feedback-unauthenticated?service=$contactFormServiceIdentifier"
+  override lazy val governmentGatewayUrl: String = "http://www.ref.gateway.gov.uk/"
 }


### PR DESCRIPTION
So that we can link to the Reference (test) instance of GG in non-production environments.