### PR TITLE
[FD,TA] Make start.path follow URL path conventions

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/config/frontendAppConfig.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/config/frontendAppConfig.scala
@@ -68,5 +68,5 @@ class FrontendAppConfig extends AppConfig with StrictConfig with ServicesConfig 
   override lazy val blacklistedPostcodes: Set[String] =
     PostcodesLoader.load("/po_box_postcodes_abp_49.csv").map(x => x.toUpperCase.replace(" ", "")).toSet
   override lazy val journeyName: String = getConfString("address-lookup-frontend.journeyName", "")
-  override lazy val agentServicesAccountUrl: String = s"$servicesAccountUrl/$servicesAccountPath"
+  override lazy val agentServicesAccountUrl: String = s"$servicesAccountUrl$servicesAccountPath"
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,7 +69,7 @@ Dev {
 
       agent-services-account-frontend {
         external-url = "http://localhost:9401"
-        start.path = "agent-services-account"
+        start.path = "/agent-services-account"
       }
 
       government-gateway-authentication {
@@ -121,7 +121,7 @@ Test {
 
       agent-services-account-frontend {
         external-url = "http://localhost:9401"
-        start.path = "agent-services-account"
+        start.path = "/agent-services-account"
       }
 
       government-gateway-authentication {
@@ -175,7 +175,7 @@ Prod {
 
       agent-services-account-frontend {
         external-url = "https://www.tax.service.gov.uk"
-        start.path = "agent-services-account"
+        start.path = "/agent-services-account"
       }
 
       government-gateway-authentication {


### PR DESCRIPTION
The path component of a URL includes the leading slash - see for example https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#Basics_anatomy_of_a_URL