### PR TITLE
[APB-2013][JR] Allow agents on the manually assured agents list.

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/audit/AuditService.scala
@@ -89,8 +89,9 @@ class AuditService @Inject()(val auditConnector: AuditConnector, authConnector: 
 
     auditData.set("utr", knownFactsResult.utr)
       .set("postcode", knownFactsResult.postcode)
-      .set("passSaAgentAssuranceCheck", assuranceResults.hasAcceptableNumberOfSAClients)
-      .set("passPayeAgentAssuranceCheck", assuranceResults.hasAcceptableNumberOfPayeClients)
+
+    assuranceResults.hasAcceptableNumberOfSAClients.foreach(auditData.set("passSaAgentAssuranceCheck", _))
+    assuranceResults.hasAcceptableNumberOfPayeClients.foreach(auditData.set("passPayeAgentAssuranceCheck", _))
 
     //TODO auditData.set("refuseToDealWith", ?)
 

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/models/AssuranceResults.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/models/AssuranceResults.scala
@@ -16,6 +16,34 @@
 
 package uk.gov.hmrc.agentsubscriptionfrontend.models
 
-case class AssuranceResults(
-                             hasAcceptableNumberOfPayeClients: Boolean,
-                             hasAcceptableNumberOfSAClients: Boolean)
+case class AssuranceResults(isOnRefusalToDealWithList: Boolean,
+                            isManuallyAssured: Boolean,
+                            hasAcceptableNumberOfPayeClients: Option[Boolean],
+                            hasAcceptableNumberOfSAClients: Option[Boolean])
+
+object AssuranceResults {
+  object RefuseToDealWith {
+    def unapply(maybeAssuranceResults: Some[AssuranceResults]): Option[AssuranceResults] =
+      maybeAssuranceResults.filter(_.isOnRefusalToDealWithList )
+  }
+
+  object ManuallyAssured {
+    def unapply(maybeAssuranceResults: Some[AssuranceResults]): Option[AssuranceResults] =
+      maybeAssuranceResults.filter(_.isManuallyAssured)
+  }
+
+  object CheckedInvisibleAssuranceAndPassed {
+    def unapply(maybeAssuranceResults: Some[AssuranceResults]): Option[AssuranceResults] = maybeAssuranceResults match {
+      case Some(AssuranceResults(false, false, Some(true), _)) => maybeAssuranceResults
+      case Some(AssuranceResults(false, false, _ ,Some(true))) => maybeAssuranceResults
+      case _ => None
+    }
+  }
+
+  object CheckedInvisibleAssuranceAndFailed {
+    def unapply(maybeAssuranceResults: Some[AssuranceResults]): Option[AssuranceResults] = maybeAssuranceResults match {
+      case Some(AssuranceResults(false, false, Some(false), Some(false))) => maybeAssuranceResults
+      case _ => None
+    }
+  }
+}

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/service/AssuranceService.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/service/AssuranceService.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsubscriptionfrontend.service
+
+import javax.inject.{Inject, Named, Singleton}
+
+import play.api.Logger
+import play.api.mvc.AnyContent
+import uk.gov.hmrc.agentmtdidentifiers.model.Utr
+import uk.gov.hmrc.agentsubscriptionfrontend.audit.AuditService
+import uk.gov.hmrc.agentsubscriptionfrontend.auth.AgentRequest
+import uk.gov.hmrc.agentsubscriptionfrontend.connectors.AgentAssuranceConnector
+import uk.gov.hmrc.agentsubscriptionfrontend.models._
+import uk.gov.hmrc.domain.{Nino, SaAgentReference, TaxIdentifier}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.frontend.auth.AuthContext
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AssuranceService @Inject()(@Named("agentAssuranceFlag") agentAssuranceFlag: Boolean,
+                                 agentAssuranceConnector: AgentAssuranceConnector,
+                                 auditService: AuditService,
+                                 sessionStoreService: SessionStoreService) {
+
+  def assureIsAgent(utr: Utr)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[AssuranceResults]] = {
+    if (agentAssuranceFlag) {
+      agentAssuranceConnector.isManuallyAssuredAgent(utr).flatMap { isManuallyAssured =>
+        if(isManuallyAssured)
+          Future.successful(None)
+        else {
+          val futurePaye = agentAssuranceConnector.hasAcceptableNumberOfPayeClients
+          val futureSA = agentAssuranceConnector.hasAcceptableNumberOfSAClients
+
+          for {
+            hasAcceptableNumberOfPayeClients <- futurePaye
+            hasAcceptableNumberOfSAClients <- futureSA
+          } yield Some(AssuranceResults(hasAcceptableNumberOfPayeClients, hasAcceptableNumberOfSAClients))
+        }
+      }
+    }
+    else Future.successful(None)
+  }
+
+  def isOnRefusalToDealWithList(utr: Utr)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Boolean]] = {
+    if(agentAssuranceFlag)
+      agentAssuranceConnector.isR2DWAgent(utr).map(Some(_))
+    else
+      Future.successful(None)
+  }
+
+  def checkActiveCesaRelationship(userEnteredNinoOrUtr: TaxIdentifier, name: String,
+                                  saAgentReference: SaAgentReference)
+                                 (implicit hc: HeaderCarrier,
+                                  ec: ExecutionContext,
+                                  request: AgentRequest[AnyContent], authContext: AuthContext): Future[Boolean] = {
+    agentAssuranceConnector.hasActiveCesaRelationship(userEnteredNinoOrUtr, name, saAgentReference).map { relationshipExists =>
+      val (userEnteredNino, userEnteredUtr) = userEnteredNinoOrUtr match {
+        case nino @ Nino(_) => (Some(nino), None)
+        case utr @ Utr(_) => (None, Some(utr))
+      }
+
+      for {
+        knownFactResultOpt <- sessionStoreService.fetchKnownFactsResult
+        _ <- knownFactResultOpt match {
+          case Some(knownFactsResult) =>
+            auditService.sendAgentAssuranceAuditEvent(knownFactsResult,
+              AssuranceResults(false, false),
+              Some(AssuranceCheckInput(Some(relationshipExists), Some(saAgentReference.value), userEnteredUtr, userEnteredNino)))
+          case None =>
+            Future.successful(Logger.warn("Could not send audit events due to empty knownfacts results"))
+        }
+      } yield ()
+
+      relationshipExists
+    }
+  }
+}

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerISpec.scala
@@ -436,7 +436,12 @@ trait CheckAgencyControllerISpec extends BaseISpec with SessionDataMissingSpec {
   }
 
 
-  def verifyAgentAssuranceAuditRequestSent(passPayeAgentAssuranceCheck: Boolean, passSaAgentAssuranceCheck: Boolean): Unit = {
+  def verifyAgentAssuranceAuditRequestSent(passPayeAgentAssuranceCheck: Option[Boolean], passSaAgentAssuranceCheck: Option[Boolean]): Unit = {
+    val optional = Seq(
+      passPayeAgentAssuranceCheck.map("passPayeAgentAssuranceCheck" -> _.toString),
+      passSaAgentAssuranceCheck.map("passSaAgentAssuranceCheck" -> _.toString)
+    ).flatten
+
     verifyAuditRequestSent(1, AgentSubscriptionFrontendEvent.AgentAssurance,
       detail = Map(
         "utr" -> validUtr.value,
@@ -444,13 +449,11 @@ trait CheckAgencyControllerISpec extends BaseISpec with SessionDataMissingSpec {
         "isEnrolledSAAgent" -> "true",
         "saAgentRef" -> "FOO1234",
         //TODO "refuseToDealWith" -> ?,
-        "passSaAgentAssuranceCheck" -> passSaAgentAssuranceCheck.toString,
         "isEnrolledPAYEAgent" -> "true",
         "payeAgentRef" -> "HZ1234",
-        "passPayeAgentAssuranceCheck" -> passPayeAgentAssuranceCheck.toString,
         "authProviderId" -> "12345-credId",
         "authProviderType" -> "GovernmentGateway"
-      ),
+      ) ++ optional,
       tags = Map(
         "transactionName" -> "agent-assurance",
         "path" -> "/"

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerISpec.scala
@@ -156,7 +156,7 @@ trait CheckAgencyControllerISpec extends BaseISpec with SessionDataMissingSpec {
     "redirect to no-agency-found page when no matching registration found by agent-subscription" in {
       isEnrolledForNonMtdServices(subscribingAgent)
       withNonMatchingUtrAndPostcode(validUtr, validPostcode)
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
       implicit val request = authenticatedRequest()
         .withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -169,7 +169,7 @@ trait CheckAgencyControllerISpec extends BaseISpec with SessionDataMissingSpec {
     "propagate an exception when there is no organisation name" in {
       withNoOrganisationName(validUtr, validPostcode)
       isEnrolledForNonMtdServices(subscribingAgent)
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
       implicit val request = authenticatedRequest()
         .withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val e = intercept[IllegalStateException] {

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerWithAssuranceFlagISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerWithAssuranceFlagISpec.scala
@@ -35,7 +35,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -54,7 +55,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -71,7 +73,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -86,7 +89,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsNotAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsNotAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -101,7 +105,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsNotAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsNotAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest().withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -117,7 +122,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsNotAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsNotAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -132,7 +138,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsNotAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -147,7 +154,8 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       isEnrolledForNonMtdServices(subscribingAgent)
       givenUserIsAnAgentWithAnAcceptableNumberOfPAYEClients
       givenUserIsNotAnAgentWithAnAcceptableNumberOfSAClients
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -159,7 +167,7 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
 
     "redirect to setup incomplete when agent's utr is in the R2DW list" in {
       isEnrolledForNonMtdServices(subscribingAgent)
-      givenUtrIsForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsForbidden(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
@@ -167,26 +175,80 @@ class CheckAgencyControllerWithAssuranceFlagISpec extends CheckAgencyControllerI
       status(result) shouldBe 303
       redirectLocation(result) shouldBe Some(routes.StartController.setupIncomplete().url)
       verify(0, getRequestedFor(urlPathEqualTo(s"/agent-subscription/registration/${encodePathSegment(validUtr.value)}/postcode/${encodePathSegment(validPostcode)}")))
+      verifyCheckRefusalToDealWith(1, validUtr.value)
+      verifyCheckAgentIsManuallyAssured(0, validUtr.value)
+      verifyCheckForAcceptableNumberOfPAYEClientsUrl(0)
+      verifyCheckForAcceptableNumberOfSAClients(0)
     }
 
     "continue checks when UTR is not found the R2DW list" in {
+      withMatchingUtrAndPostcode(validUtr, validPostcode)
       isEnrolledForNonMtdServices(subscribingAgent)
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
+      givenUserIsAnAgentWithAnAcceptableNumberOfPAYEClients
+      givenUserIsAnAgentWithAnAcceptableNumberOfSAClients
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       val result = await(controller.checkAgencyStatus(request))
 
       verify(1, getRequestedFor(urlPathEqualTo(s"/agent-subscription/registration/${encodePathSegment(validUtr.value)}/postcode/${encodePathSegment(validPostcode)}")))
+      verifyCheckRefusalToDealWith(1, validUtr.value)
+      verifyCheckAgentIsManuallyAssured(1, validUtr.value)
+      verifyCheckForAcceptableNumberOfPAYEClientsUrl(1)
+      verifyCheckForAcceptableNumberOfSAClients(1)
     }
 
     "exception received due to missing config in R2DW" in {
       isEnrolledForNonMtdServices(subscribingAgent)
-      given404ReturnedForR2dw(validUtr.value)
+      givenRefusalToDealWithReturns404(validUtr.value)
 
       implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
       an[IllegalStateException] shouldBe thrownBy(await(controller.checkAgencyStatus(request)))
 
       verify(0, getRequestedFor(urlPathEqualTo(s"/agent-subscription/registration/${encodePathSegment(validUtr.value)}/postcode/${encodePathSegment(validPostcode)}")))
+    }
+
+    "proceed direct to showConfirmYourAgency and skip assurance checks " +
+    "when agent's UTR is not in the Refusal to Deal With list but is in the Manually Assured Agents list" in {
+      withMatchingUtrAndPostcode(validUtr, validPostcode)
+      isEnrolledForNonMtdServices(subscribingAgent)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsManuallyAssured(validUtr.value)
+
+      implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
+      val result = await(controller.checkAgencyStatus(request))
+
+      status(result) shouldBe 303
+      redirectLocation(result) shouldBe Some(routes.CheckAgencyController.showConfirmYourAgency().url)
+
+      verifyCheckRefusalToDealWith(1, validUtr.value)
+      verifyCheckAgentIsManuallyAssured(1, validUtr.value)
+      verify(1, getRequestedFor(urlPathEqualTo(s"/agent-subscription/registration/${encodePathSegment(validUtr.value)}/postcode/${encodePathSegment(validPostcode)}")))
+      verifyCheckForAcceptableNumberOfPAYEClientsUrl(0)
+      verifyCheckForAcceptableNumberOfSAClients(0)
+      verifyAuditRequestNotSent(AgentSubscriptionFrontendEvent.AgentAssurance)
+    }
+
+    "perform all usual assurance checks when agent's UTR is not in the Manually Assured Agents list" in {
+      withMatchingUtrAndPostcode(validUtr, validPostcode)
+      isEnrolledForNonMtdServices(subscribingAgent)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
+      givenAgentIsNotManuallyAssured(validUtr.value)
+      givenUserIsAnAgentWithAnAcceptableNumberOfPAYEClients
+      givenUserIsAnAgentWithAnAcceptableNumberOfSAClients
+
+      implicit val request = authenticatedRequest(subscribingAgent).withFormUrlEncodedBody("utr" -> validUtr.value, "postcode" -> validPostcode)
+      val result = await(controller.checkAgencyStatus(request))
+
+      status(result) shouldBe 303
+      redirectLocation(result) shouldBe Some(routes.CheckAgencyController.showConfirmYourAgency().url)
+
+      verifyCheckRefusalToDealWith(1, validUtr.value)
+      verifyCheckAgentIsManuallyAssured(1, validUtr.value)
+      verify(1, getRequestedFor(urlPathEqualTo(s"/agent-subscription/registration/${encodePathSegment(validUtr.value)}/postcode/${encodePathSegment(validPostcode)}")))
+      verifyCheckForAcceptableNumberOfPAYEClientsUrl(1)
+      verifyCheckForAcceptableNumberOfSAClients(1)
     }
   }
 }

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerWithoutAssuranceFlagISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/CheckAgencyControllerWithoutAssuranceFlagISpec.scala
@@ -4,7 +4,7 @@ import play.api.test.Helpers._
 import play.api.test.Helpers.redirectLocation
 import uk.gov.hmrc.agentsubscriptionfrontend.audit.AgentSubscriptionFrontendEvent
 import uk.gov.hmrc.agentsubscriptionfrontend.models.KnownFactsResult
-import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AgentAssuranceStub.givenUtrIsNotForbidden
+import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AgentAssuranceStub.givenRefusalToDealWithUtrIsNotForbidden
 import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AgentSubscriptionStub.withMatchingUtrAndPostcode
 import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AuthStub.{hasNoEnrolments, isEnrolledForNonMtdServices}
 import uk.gov.hmrc.agentsubscriptionfrontend.support.SampleUsers.subscribingAgent
@@ -17,7 +17,7 @@ class CheckAgencyControllerWithoutAssuranceFlagISpec extends CheckAgencyControll
     "redirect to confirm agency page and store known facts result in the session store when a matching registration is found for the UTR and postcode" in {
       withMatchingUtrAndPostcode(validUtr, validPostcode)
       isEnrolledForNonMtdServices(subscribingAgent)
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
 
 
       implicit val request = authenticatedRequest()
@@ -35,7 +35,7 @@ class CheckAgencyControllerWithoutAssuranceFlagISpec extends CheckAgencyControll
     "store isSubscribedToAgentServices = false in session when the business registration found by agent-subscription is not already subscribed" in {
       withMatchingUtrAndPostcode(validUtr, validPostcode)
       isEnrolledForNonMtdServices(subscribingAgent)
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
 
 
       implicit val request = authenticatedRequest()
@@ -51,7 +51,7 @@ class CheckAgencyControllerWithoutAssuranceFlagISpec extends CheckAgencyControll
     "redirect to already subscribed page when the business registration found by agent-subscription is already subscribed" in {
       withMatchingUtrAndPostcode(validUtr, validPostcode, isSubscribedToAgentServices = true)
       isEnrolledForNonMtdServices(subscribingAgent)
-      givenUtrIsNotForbidden(validUtr.value)
+      givenRefusalToDealWithUtrIsNotForbidden(validUtr.value)
 
 
       implicit val request = authenticatedRequest()

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/stubs/AgentAssuranceStub.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/stubs/AgentAssuranceStub.scala
@@ -18,6 +18,9 @@ object AgentAssuranceStub {
   def givenAnExceptionOccursDuringThePAYEClientCheck: StubMapping =
     stubFor(get(urlEqualTo(checkForAcceptableNumberOfPAYEClientsUrl)).willReturn(aResponse().withStatus(404)))
 
+  def verifyCheckForAcceptableNumberOfPAYEClientsUrl(times: Int) =
+    verify(times, getRequestedFor(urlEqualTo(checkForAcceptableNumberOfSAClientsUrl)))
+
   val checkForAcceptableNumberOfSAClientsUrl = "/agent-assurance/acceptableNumberOfClients/service/IR-SA"
 
   def givenUserIsAnAgentWithAnAcceptableNumberOfSAClients: StubMapping =
@@ -32,16 +35,42 @@ object AgentAssuranceStub {
   def givenAnExceptionOccursDuringTheSAClientCheck: StubMapping =
     stubFor(get(urlEqualTo(checkForAcceptableNumberOfSAClientsUrl)).willReturn(aResponse().withStatus(404)))
 
+  def verifyCheckForAcceptableNumberOfSAClients(times: Int) =
+    verify(times, getRequestedFor(urlEqualTo(checkForAcceptableNumberOfSAClientsUrl)))
+
   val r2dwUrl = "/agent-assurance/refusal-to-deal-with"
 
-  def givenUtrIsForbidden(utr: String): StubMapping =
+  def givenRefusalToDealWithUtrIsForbidden(utr: String): StubMapping =
     stubFor(get(urlEqualTo(s"$r2dwUrl/$utr")).willReturn(aResponse().withStatus(403)))
 
-  def givenUtrIsNotForbidden(utr: String): StubMapping =
+  def givenRefusalToDealWithUtrIsNotForbidden(utr: String): StubMapping =
     stubFor(get(urlEqualTo(s"$r2dwUrl/$utr")).willReturn(aResponse().withStatus(200)))
 
-  def given404ReturnedForR2dw(utr: String): StubMapping =
+  def givenRefusalToDealWithReturns404(utr: String): StubMapping =
     stubFor(get(urlEqualTo(s"$r2dwUrl/$utr")).willReturn(aResponse().withStatus(404)))
+
+  def verifyCheckRefusalToDealWith(times: Int, utr: String) =
+    verify(times, getRequestedFor(urlEqualTo(s"$r2dwUrl/$utr")))
+
+  val manuallyAssuredAgentUrl = (utr: String) => urlEqualTo(s"/agent-assurance/manually-assured/$utr")
+
+  def givenAgentIsNotManuallyAssured(utr: String): StubMapping =
+    stubFor(get(manuallyAssuredAgentUrl(utr))
+      .willReturn(aResponse()
+        .withStatus(403)))
+
+  def givenAgentIsManuallyAssured(utr: String): StubMapping =
+    stubFor(get(manuallyAssuredAgentUrl(utr))
+      .willReturn(aResponse()
+        .withStatus(200)))
+
+  def givenManuallyAssuredAgentsReturns(utr: String, status: Int): StubMapping =
+    stubFor(get(manuallyAssuredAgentUrl(utr))
+      .willReturn(aResponse()
+        .withStatus(status)))
+
+  def verifyCheckAgentIsManuallyAssured(times: Int, utr: String) =
+    verify(times, getRequestedFor(manuallyAssuredAgentUrl(utr)))
 
   def givenNinoAGoodCombinationAndUserHasRelationshipInCesa(ninoOrUtr: String, valueOfNinoOrUtr: String, saAgentReference: String): StubMapping =
     stubFor(get(urlEqualTo(s"/agent-assurance/activeCesaRelationship/nino/AA123456A/saAgentReference/SA6012"))

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -10,12 +10,12 @@ object FrontendBuild extends Build with MicroService {
 
   val compile = Seq(
     ws,
-    "uk.gov.hmrc" %% "frontend-bootstrap" % "8.11.0",
+    "uk.gov.hmrc" %% "frontend-bootstrap" % "8.19.0",
     "uk.gov.hmrc" %% "play-reactivemongo" % "5.2.0",
     "uk.gov.hmrc" %% "play-partials" % "6.1.0",
-    "uk.gov.hmrc" %% "http-caching-client" % "7.0.0",
+    "uk.gov.hmrc" %% "http-caching-client" % "7.1.0",
     "uk.gov.hmrc" %% "passcode-verification" % "5.0.0",
-    "uk.gov.hmrc" %% "domain" % "5.0.0",
+    "uk.gov.hmrc" %% "domain" % "5.1.0",
     "uk.gov.hmrc" %% "agent-kenshoo-monitoring" % "2.4.0",
     "uk.gov.hmrc" %% "agent-mtd-identifiers" % "0.5.0",
     "de.threedimensions" %% "metrics-play" % "2.5.13",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.7.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.8.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")
 

--- a/test/uk/gov/hmrc/agentsubscriptionfrontend/auth/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/agentsubscriptionfrontend/auth/AuthActionSpec.scala
@@ -26,9 +26,9 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.redirectLocation
 import uk.gov.hmrc.agentsubscriptionfrontend.audit.AuditService
 import uk.gov.hmrc.agentsubscriptionfrontend.config.AppConfig
-import uk.gov.hmrc.agentsubscriptionfrontend.connectors.{AgentAssuranceConnector, AgentSubscriptionConnector}
+import uk.gov.hmrc.agentsubscriptionfrontend.connectors.{AgentSubscriptionConnector}
 import uk.gov.hmrc.agentsubscriptionfrontend.controllers.{CheckAgencyController, ContinueUrlActions, routes}
-import uk.gov.hmrc.agentsubscriptionfrontend.service.SessionStoreService
+import uk.gov.hmrc.agentsubscriptionfrontend.service.{AssuranceService, SessionStoreService}
 import uk.gov.hmrc.agentsubscriptionfrontend.support.TestAppConfig
 import uk.gov.hmrc.agentsubscriptionfrontend.support.TestMessagesApi.testMessagesApi
 import uk.gov.hmrc.agentsubscriptionfrontend.support.passcode.TestPasscodeVerificationConfig
@@ -38,8 +38,8 @@ import uk.gov.hmrc.play.frontend.auth._
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, Authority, ConfidenceLevel}
 import uk.gov.hmrc.play.test.UnitSpec
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 class AuthActionSpec extends UnitSpec with MockitoSugar {
@@ -58,10 +58,10 @@ class AuthActionSpec extends UnitSpec with MockitoSugar {
       val authConnector = mock[AuthConnector]
       val agentSubscriptionConnector = mock[AgentSubscriptionConnector]
       val sessionStoreService = mock[SessionStoreService]
+      val assuranceService = mock[AssuranceService]
       val passcodeVerificationConfig = new TestPasscodeVerificationConfig(enabled = false)
       val passcodeAuthenticationProvider = new PasscodeAuthenticationProvider(passcodeVerificationConfig)
       val continueUrlActions = mock[ContinueUrlActions]
-      val agentAssuranceConnector = mock[AgentAssuranceConnector]
       val auditService = mock[AuditService]
       val metrics = mock[Metrics]
 
@@ -73,8 +73,7 @@ class AuthActionSpec extends UnitSpec with MockitoSugar {
       when(authConnector.getEnrolments(any[AuthContext])(any[HeaderCarrier], any[HttpReads[List[Enrolment]]], any[ExecutionContext]))
         .thenReturn(Future successful List.empty[Enrolment])
 
-      val controller = new CheckAgencyController(
-        false, agentAssuranceConnector, testMessagesApi, authConnector, passcodeVerificationConfig,
+      val controller = new CheckAgencyController(assuranceService, testMessagesApi, authConnector, passcodeVerificationConfig,
         passcodeAuthenticationProvider, agentSubscriptionConnector, sessionStoreService, continueUrlActions, auditService, metrics)
 
       intercept[Upstream5xxResponse] {


### PR DESCRIPTION
Also has a small refactor to extract out some agent assurance logic from the CheckAgencyController into a new AssuranceService.