### PR TITLE
[APB-4095][MP] Rework partial subscription scenarios now record is deleted after ETMP record creation

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/connectors/AgentSubscriptionConnector.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/connectors/AgentSubscriptionConnector.scala
@@ -79,13 +79,6 @@ class AgentSubscriptionConnector @Inject()(
         .map(handleUpdateJourneyResponse(_, path))
     }
 
-  def deleteJourney(authProviderId: AuthProviderId)(implicit hc: HeaderCarrier): Future[Unit] =
-    monitor("ConsumedAPI-Agent-Subscription-delete-DELETE") {
-      val path = s"/agent-subscription/subscription/journey/primaryId/${encodePathSegment(authProviderId.id)}"
-      val url = new URL(baseUrl, path)
-      http.DELETE[HttpResponse](url.toString).map(handleUpdateJourneyResponse(_, path))
-    }
-
   private def handleUpdateJourneyResponse(httpResponse: HttpResponse, path: String): Unit =
     httpResponse.status match {
       case 204    => ()

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessIdentificationController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessIdentificationController.scala
@@ -167,16 +167,11 @@ class BusinessIdentificationController @Inject()(
           .createJourneyRecord(existingSession, agent)
           .map(_ => Redirect(routes.TaskListController.showTaskList()))
 
-        agent.cleanCredsFold(
-
-          isDirty = createRecordAndRedirectToTasklist())(
-
-          isClean = subscriptionService.handlePartiallySubscribedAndRedirect(
+          subscriptionService.handlePartiallySubscribedAndRedirect(
             agent,
             existingSession.utr.getOrElse(Utr("")),
             existingSession.postcode.getOrElse(Postcode("")))(
             whenNotPartiallySubscribed = createRecordAndRedirectToTasklist())
-          )
     }
 
   def showBusinessEmailForm: Action[AnyContent] = Action.async { implicit request =>

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessTypeController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessTypeController.scala
@@ -51,12 +51,7 @@ class BusinessTypeController @Inject()(
     withSubscribingAgent { implicit agent =>
       continueUrlActions.withMaybeContinueUrlCached {
         agent.subscriptionJourneyRecord match {
-          case Some(sjr) =>
-            agent.cleanCredsFold(isDirty = Future.successful(Redirect(routes.TaskListController.showTaskList())))(
-              isClean = subscriptionService
-                .handlePartiallySubscribedAndRedirect(agent, sjr.businessDetails.utr, sjr.businessDetails.postcode)(
-                  whenNotPartiallySubscribed = Redirect(routes.TaskListController.showTaskList())))
-
+          case Some(_) => Future.successful(Redirect(routes.TaskListController.showTaskList()))
           case None =>
             sessionStoreService.fetchAgentSession.flatMap {
               case Some(agentSession) =>

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/StartController.scala
@@ -107,15 +107,4 @@ class StartController @Inject()(
   def showCannotCreateAccount: Action[AnyContent] = Action { implicit request =>
     Ok(html.cannot_create_account())
   }
-
-  // TODO review partial subscription handling
-  private def handlePartialSubscription(kfcUtr: Utr, kfcPostcode: String, agentSession: AgentSession)(
-    implicit request: Request[_],
-    hc: HeaderCarrier): Future[Result] =
-    subscriptionService
-      .completePartialSubscription(kfcUtr, Postcode(kfcPostcode))
-      .flatMap { _ =>
-        mark("Count-Subscription-PartialSubscriptionCompleted")
-        Redirect(routes.SubscriptionController.showSubscriptionComplete())
-      }
 }

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
@@ -120,15 +120,12 @@ class SubscriptionController @Inject()(
         val sjr = agent.getMandatorySubscriptionRecord
         (sjr.businessDetails.utr, sjr.businessDetails.postcode, sjr.businessDetails.registration, sjr.amlsData) match {
           case (utr, postcode, Some(registration), amlsData) =>
-            subscriptionService.handlePartiallySubscribedAndRedirect(agent, sjr.businessDetails.utr, sjr.businessDetails.postcode)(
-              whenNotPartiallySubscribed = {
                     for {
                     _ <- updateSessionBeforeSubscribing(registration)
                     subscriptionResponse <- subscriptionService
                       .subscribe(utr, postcode, registration, amlsData)
                     result <- redirectSubscriptionResponse(subscriptionResponse, agent)
                     }yield result
-              })
 
           case _ =>
             Logger(getClass).warn(s"Missing data in session, redirecting back to /business-type")

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.agentsubscriptionfrontend.util.toFuture
 import uk.gov.hmrc.agentsubscriptionfrontend.views.html
 import uk.gov.hmrc.agentsubscriptionfrontend.views.html.sign_in_new_id
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.http.HttpException
+import uk.gov.hmrc.http.{HeaderCarrier, HttpException}
 import uk.gov.hmrc.play.binders.ContinueUrl
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -101,6 +101,19 @@ class SubscriptionController @Inject()(
     }
   }
 
+  private def updateSessionBeforeSubscribing(registration: Registration)(implicit hc: HeaderCarrier) = {
+    val agencyName = registration.taxpayerName
+    val agencyEmail = registration.emailAddress
+    val agencyAddress = registration.address
+
+    sessionStoreService.cacheAgentSession(AgentSession(registration = Some(
+      Registration(taxpayerName = agencyName,
+        isSubscribedToAgentServices = false,
+        isSubscribedToETMP = false,
+        agencyAddress,
+        agencyEmail))))
+  }
+
   def submitCheckAnswers: Action[AnyContent] = Action.async { implicit request =>
     withSubscribingAgent { agent =>
       agent.withCleanCredsOrSignIn {
@@ -108,9 +121,14 @@ class SubscriptionController @Inject()(
         (sjr.businessDetails.utr, sjr.businessDetails.postcode, sjr.businessDetails.registration, sjr.amlsData) match {
           case (utr, postcode, Some(registration), amlsData) =>
             subscriptionService.handlePartiallySubscribedAndRedirect(agent, sjr.businessDetails.utr, sjr.businessDetails.postcode)(
-              whenNotPartiallySubscribed = subscriptionService
-              .subscribe(utr, postcode, registration, amlsData)
-              .flatMap(redirectSubscriptionResponse(_, agent)))
+              whenNotPartiallySubscribed = {
+                    for {
+                    _ <- updateSessionBeforeSubscribing(registration)
+                    subscriptionResponse <- subscriptionService
+                      .subscribe(utr, postcode, registration, amlsData)
+                    result <- redirectSubscriptionResponse(subscriptionResponse, agent)
+                    }yield result
+              })
 
           case _ =>
             Logger(getClass).warn(s"Missing data in session, redirecting back to /business-type")
@@ -135,9 +153,6 @@ class SubscriptionController @Inject()(
       case Right((_, _)) =>
         mark("Count-Subscription-Complete")
         for {
-          sjr <- agent.getMandatorySubscriptionRecord
-          newRecord <- sjr.copy(subscriptionCreated = true)
-          _ <- subscriptionJourneyService.saveJourneyRecord(newRecord)
           gotoComplete <- Redirect(routes.SubscriptionController.showSubscriptionComplete())
         } yield gotoComplete
 
@@ -207,7 +222,7 @@ class SubscriptionController @Inject()(
         None
     }
 
-    def handleRegistrationAndGoToComplete(registration: Option[Registration], result: (String, String, ContinueUrl) => Future[Result]): Future[Result] = {
+    def handleRegistrationAndGoToComplete(registration: Option[Registration], result: (String, String, ContinueUrl) => Result): Future[Result] = {
       registration match {
         case Some(registration) =>
           val agencyName = registration.taxpayerName.getOrElse(
@@ -231,14 +246,12 @@ class SubscriptionController @Inject()(
 
     withSubscribedAgent { (arn, sjrOpt) =>
       sjrOpt match {
-        case Some(sjr) => handleRegistrationAndGoToComplete(sjr.businessDetails.registration, (agencyName, agencyEmail, continueUrl) => for {
-                          _ <- subscriptionJourneyService.deleteJourneyRecord(sjr.authProviderId)
-                          result <- Ok(html.subscription_complete(continueUrl.url, arn.value, agencyName, agencyEmail))
-                        } yield result)
+        case Some(sjr) => handleRegistrationAndGoToComplete(sjr.businessDetails.registration, (agencyName, agencyEmail, continueUrl) =>
+                          Ok(html.subscription_complete(continueUrl.url, arn.value, agencyName, agencyEmail)))
 
         case None => sessionStoreService.fetchAgentSession.flatMap {
           case Some(agentSession) => handleRegistrationAndGoToComplete(agentSession.registration, (agencyName, agencyEmail, continueUrl) =>
-            Future successful Ok(html.subscription_complete(continueUrl.url, arn.value, agencyName, agencyEmail)))
+            Ok(html.subscription_complete(continueUrl.url, arn.value, agencyName, agencyEmail)))
 
           case None => throw new RuntimeException("no record found for agent")
         }

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionController.scala
@@ -101,6 +101,7 @@ class SubscriptionController @Inject()(
     }
   }
 
+  //helper function to copy record details to session before the record is deleted allowing them to be displayed on subscription complete page
   private def updateSessionBeforeSubscribing(registration: Registration)(implicit hc: HeaderCarrier) = {
     val agencyName = registration.taxpayerName
     val agencyEmail = registration.emailAddress

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/service/SubscriptionJourneyService.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/service/SubscriptionJourneyService.scala
@@ -63,11 +63,6 @@ class SubscriptionJourneyService @Inject()(agentSubscriptionConnector: AgentSubs
     implicit hc: HeaderCarrier): Future[Unit] =
     agentSubscriptionConnector.createOrUpdateJourney(subscriptionJourneyRecord)
 
-  def deleteJourneyRecord(authProviderId: AuthProviderId)(implicit hc: HeaderCarrier): Future[Unit] =
-    agentSubscriptionConnector.deleteJourney(authProviderId).recover {
-      case NonFatal(ex) => Logger(getClass).warn("Failed to delete journey record", ex)
-    }
-
   def createJourneyRecord(agentSession: AgentSession, agent: Agent)(implicit hc: HeaderCarrier): Future[Unit] = {
     val sjr =
       SubscriptionJourneyRecord

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/connectors/AgentSubscriptionConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/connectors/AgentSubscriptionConnectorISpec.scala
@@ -102,21 +102,6 @@ class AgentSubscriptionConnectorISpec extends BaseISpec with MetricTestSupport {
     }
   }
 
-  "deleteJourney" should {
-    "return unit when record is successfully deleted" in {
-      AgentSubscriptionJourneyStub.givenSubscriptionRecordDeleted(authProviderId)
-      val result = await(connector.deleteJourney(authProviderId))
-      result shouldBe (())
-    }
-
-    "throw an exception when there is a problem deleting the record" in {
-      AgentSubscriptionJourneyStub.givenSubscriptionRecordNotDeleted(authProviderId)
-      intercept[Upstream5xxResponse] {
-        await(connector.deleteJourney(authProviderId))
-      }
-    }
-  }
-
   "getRegistration" should {
 
     "return a subscribed Registration when agent-subscription returns a 200 response (for a matching UTR and postcode)" in {

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessTypeControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessTypeControllerISpec.scala
@@ -86,18 +86,6 @@ class BusinessTypeControllerISpec extends BaseISpec with SessionDataMissingSpec 
       redirectLocation(result) shouldBe Some(routes.TaskListController.showTaskList().url)
     }
 
-    "redirect to subscription complete if the agent has a subscription journey record has clean creds and is partially subscribed" in {
-      givenSubscriptionJourneyRecordExists(AuthProviderId("12345-credId"),
-        TestData.minimalSubscriptionJourneyRecord(AuthProviderId("12345-credId")))
-      withPartiallySubscribedAgent(TestData.validUtr, TestData.validPostcode)
-      partialSubscriptionWillSucceed(CompletePartialSubscriptionBody(TestData.validUtr, SubscriptionRequestKnownFacts(TestData.validPostcode)))
-      val request = authenticatedAs(subscribingCleanAgentWithoutEnrolments)
-      val result = await(controller.showBusinessTypeForm(request))
-
-      status(result) shouldBe 303
-      redirectLocation(result) shouldBe Some(routes.SubscriptionController.showSubscriptionComplete().url)
-    }
-
     "redirect to task list if the agent has clean creds and is not partially subscribed" in {
       givenSubscriptionJourneyRecordExists(AuthProviderId("12345-credId"),
         TestData.minimalSubscriptionJourneyRecord(AuthProviderId("12345-credId")))

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionControllerISpec.scala
@@ -611,17 +611,6 @@ class SubscriptionControllerTests extends SubscriptionControllerISpec {
         metricShouldExistAndBeUpdated("Count-Subscription-Complete")
       }
     }
-    "partially subscribe user and redirect to subscription complete" when {
-      "user is partially subscribed" in new TestSetupWithCompleteJourneyRecordAndCreate {
-        withPartiallySubscribedAgent(TestData.validUtr, TestData.validPostcode)
-        partialSubscriptionWillSucceed(CompletePartialSubscriptionBody(TestData.validUtr, SubscriptionRequestKnownFacts(TestData.validPostcode)))
-        implicit val request = authenticatedAs(subscribingCleanAgentWithoutEnrolments)
-        val result = await(controller.submitCheckAnswers(request))
-
-        status(result) shouldBe 303
-        redirectLocation(result).head shouldBe routes.SubscriptionController.showSubscriptionComplete().url
-      }
-    }
   }
 
   "GET /sign-in-with-new-user-id" should {

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/business/ConfirmBusinessISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/business/ConfirmBusinessISpec.scala
@@ -189,7 +189,7 @@ class ConfirmBusinessISpec extends BaseISpec {
 
       }
 
-      "redirect to task list if the user is partially subscribed with unclean creds" in new TestSetupNoJourneyRecord {
+      "redirect to sign in with new user ID if the user is partially subscribed with unclean creds" in new TestSetupNoJourneyRecord {
         val agentSession = AgentSession(
           Some(BusinessType.SoleTrader),
           utr = Some(utr),
@@ -206,7 +206,7 @@ class ConfirmBusinessISpec extends BaseISpec {
 
         val result = await(controller.submitConfirmBusinessForm(request))
 
-        result.header.headers(LOCATION) shouldBe routes.TaskListController.showTaskList().url
+        result.header.headers(LOCATION) shouldBe routes.SubscriptionController.showSignInWithNewID().url
       }
 
       "redirect to showBusinessEmailForm if the user has clean creds and isSubscribedToAgentServices=false and ETMP record contains empty email" in new TestSetupNoJourneyRecord {


### PR DESCRIPTION
Now that the subscription journey record is deleted upon successful creation of a record in ETMP, there is no way for a partially subscribed user to come into the journey with a subscription journey record. So we can check when the user enters their UTR and postcode if they are partially subscribed then if they are a clean creds user complete the subscription and if they are unclean creds ask them to sign in again with the clean creds they have previously created.