### PR TITLE
[APB-4361][MP] changing content on sign-in-with-new-user-id page

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SignedOutController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SignedOutController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentsubscriptionfrontend.controllers
 import com.kenshoo.play.metrics.Metrics
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Action, AnyContent, Result}
+import play.api.mvc.{Action, AnyContent}
 import uk.gov.hmrc.agentsubscriptionfrontend.config.AppConfig
 import uk.gov.hmrc.agentsubscriptionfrontend.service.{SessionStoreService, SubscriptionJourneyService}
 import uk.gov.hmrc.agentsubscriptionfrontend.support.CallOps.addParamsToUrl
@@ -46,10 +46,7 @@ class SignedOutController @Inject()(
         agentSubContinueUrlOpt <- sessionStoreService.fetchContinueUrl
         redirectUrl            <- redirectUrlActions.getUrl(agentSubContinueUrlOpt)
         continueId = {
-          agent.subscriptionJourneyRecord match {
-            case Some(sjr) if sjr.continueId.nonEmpty => sjr.continueId
-            case _                                    => None
-          }
+          agent.subscriptionJourneyRecord.flatMap(_.continueId)
         }
       } yield {
         val continueUrl =

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/views/create_new_account.scala.html
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/views/create_new_account.scala.html
@@ -27,7 +27,7 @@
     <p>@Messages("createNewAccount.p1")</p>
 
     <p>
-     <a class="button margin-right-5" href="@SignedOutController.redirectTaskListUserToCreateCleanCreds" role="button" id="buttonGoToGg">@Messages("button.register")</a>
+     <a class="button margin-right-5" href="@SignedOutController.redirectUserToCreateCleanCreds" role="button" id="buttonGoToGg">@Messages("button.register")</a>
      <a class="button--secondary" href="@routes.TaskListController.savedProgress(Some(routes.BusinessIdentificationController.showCreateNewAccount().url))">@Messages("button.saveComeBackLater")</a>
     </p>
 }

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/views/sign_in_new_id.scala.html
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/views/sign_in_new_id.scala.html
@@ -21,8 +21,9 @@
 @uk.gov.hmrc.agentsubscriptionfrontend.views.html.main_template(appConfig, title = Messages("sign-in-new-id.header"), bodyClasses = None) {
 
     <h1 class="heading-xlarge">@Messages("sign-in-new-id.header")</h1>
-    <p>@Messages("sign-in-new-id.p1")</p>
-    <p>@Messages("sign-in-new-id.p2")</p>
+            <p>@Messages("sign-in-new-id.p1")</p>
+            <p>@Messages("sign-in-new-id.p2")</p>
+            <p>@Html(Messages("sign-in-new-id.p3", routes.SignedOutController.redirectUserToCreateCleanCreds))</p>
 
-    <a class="button" href="@routes.SignedOutController.redirectToBusinessTypeForm" role="button" id="signInWithNewId">@Messages("sign-in-new-id.button")</a>
+            <a class="button" href="@routes.SignedOutController.redirectToBusinessTypeForm" role="button" id="signInWithNewId">@Messages("sign-in-new-id.button")</a>
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -98,8 +98,6 @@ GET         /sign-in-with-new-user-id                      uk.gov.hmrc.agentsubs
 
 GET         /create-clean-creds                            uk.gov.hmrc.agentsubscriptionfrontend.controllers.SignedOutController.redirectUserToCreateCleanCreds
 
-GET         /redirect-to-sos                               uk.gov.hmrc.agentsubscriptionfrontend.controllers.SignedOutController.redirectTaskListUserToCreateCleanCreds
-
 GET         /redirect-to-asaccount                         uk.gov.hmrc.agentsubscriptionfrontend.controllers.SignedOutController.redirectToASAccountPage
 GET         /start-survey                                  uk.gov.hmrc.agentsubscriptionfrontend.controllers.SignedOutController.startSurvey
 GET         /sign-out                                      uk.gov.hmrc.agentsubscriptionfrontend.controllers.SignedOutController.signOutWithContinueUrl

--- a/conf/messages
+++ b/conf/messages
@@ -440,6 +440,7 @@ postcodeNotAllowed.button=Try Again
 sign-in-new-id.header=Sign in with your new user ID
 sign-in-new-id.p1=You have not finished creating your agent services account.
 sign-in-new-id.p2=To finish this step, sign in again using the new user ID you created for your agent services account.
+sign-in-new-id.p3=If you do not have one, <a href="{0}">create a new user ID</a>, selecting the ‘Agent’ option.
 sign-in-new-id.button=Sign in with new user ID
 
 footer.links.accessibility.text=Accessibility

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SignOutControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SignOutControllerISpec.scala
@@ -29,15 +29,8 @@ class SignOutControllerISpec extends BaseISpec {
 
   "redirectToSos" should {
 
-    "redirect task list user to create clean creds" in new TestSetup {
-      private val result = await(controller.redirectTaskListUserToCreateCleanCreds(authenticatedAs(subscribingAgentEnrolledForNonMTD)))
-
-      status(result) shouldBe 303
-      redirectLocation(result).head should include(sosRedirectUrl)
-    }
-
     "redirect user to create clean creds" in new TestSetup {
-      private val result = await(controller.redirectUserToCreateCleanCreds(authenticatedAs(individual)))
+      private val result = await(controller.redirectUserToCreateCleanCreds(authenticatedAs(subscribingAgentEnrolledForNonMTD)))
 
       status(result) shouldBe 303
       redirectLocation(result).head should include(sosRedirectUrl)
@@ -46,7 +39,7 @@ class SignOutControllerISpec extends BaseISpec {
     "the SOS redirect URL should include an ID of the saved continue id" in new TestSetup {
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = authenticatedAs(subscribingAgentEnrolledForNonMTD)
 
-      private val result = await(controller.redirectTaskListUserToCreateCleanCreds(request))
+      private val result = await(controller.redirectUserToCreateCleanCreds(request))
       redirectLocation(result).head should include(
         s"continue=%2Fagent-subscription%2Freturn-after-gg-creds-created%3Fid%3Dfoo")
     }
@@ -59,19 +52,6 @@ class SignOutControllerISpec extends BaseISpec {
       redirectLocation(result).head should include(expectedSosContinueParam)
     }
 
-    "include a continue URL on user clean creds redirect if a continue URL exists in the session store" in {
-
-      val ourContinueUrl = "/test-continue-url"
-      implicit val request: FakeRequest[AnyContentAsEmpty.type] = authenticatedAs(individual)
-      sessionStoreService.currentSession.continueUrl = Some(ourContinueUrl)
-
-      assertContinueUrl(
-        await(controller.redirectUserToCreateCleanCreds(authenticatedAs(individual))),
-        ourContinueUrl
-      )
-
-    }
-
     "include a continue URL in the SOS redirect URL if a continue URL exists in the session store" in {
 
       givenSubscriptionJourneyRecordExists(id, TestData.minimalSubscriptionJourneyRecordWithAmls(id).copy(continueId = None))
@@ -81,7 +61,7 @@ class SignOutControllerISpec extends BaseISpec {
       sessionStoreService.currentSession.continueUrl = Some(ourContinueUrl)
 
       assertContinueUrl(
-        await(controller.redirectTaskListUserToCreateCleanCreds(authenticatedAs(subscribingAgentEnrolledForNonMTD))),
+        await(controller.redirectUserToCreateCleanCreds(authenticatedAs(subscribingAgentEnrolledForNonMTD))),
         ourContinueUrl
       )
 
@@ -92,7 +72,7 @@ class SignOutControllerISpec extends BaseISpec {
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = authenticatedAs(subscribingAgentEnrolledForNonMTD)
       sessionStoreService.currentSession.continueUrl = Some(ourContinueUrl)
 
-      private val result = await(controller.redirectTaskListUserToCreateCleanCreds(request))
+      private val result = await(controller.redirectUserToCreateCleanCreds(request))
 
       val sosContinueValueUnencoded =
         s"/agent-subscription/return-after-gg-creds-created?id=foo&continue=${URLEncoder.encode(ourContinueUrl, "UTF-8")}"
@@ -166,6 +146,18 @@ class SignOutControllerISpec extends BaseISpec {
       status(result) shouldBe 303
 
       redirectLocation(result).head shouldBe routes.StartController.start().url
+      result.session.get("sessionId") shouldBe empty
+    }
+  }
+
+  "redirectToBusinessTypeForm" should {
+    "redirect to the business type page and remove the session" in {
+      implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest.withSession("sessionId" -> "SomeSession")
+      val result = await(controller.redirectToBusinessTypeForm(request))
+
+      status(result) shouldBe 303
+
+      redirectLocation(result).head shouldBe routes.BusinessTypeController.showBusinessTypeForm().url
       result.session.get("sessionId") shouldBe empty
     }
   }

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SignOutControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SignOutControllerISpec.scala
@@ -64,7 +64,6 @@ class SignOutControllerISpec extends BaseISpec {
         await(controller.redirectUserToCreateCleanCreds(authenticatedAs(subscribingAgentEnrolledForNonMTD))),
         ourContinueUrl
       )
-
     }
 
     "include both an ID and a continue URL in the SOS redirect URL if both a continue URL and KnownFacts exist in the session store" in new TestSetup {

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/SubscriptionControllerISpec.scala
@@ -546,7 +546,11 @@ class SubscriptionControllerISpec extends BaseISpec with SessionDataMissingSpec 
 
       status(result) shouldBe 200
       checkHtmlResultWithBodyText(result, "Sign in with your new user ID",
-        "You have not finished creating your agent services account.")
+        "You have not finished creating your agent services account.",
+        "To finish this step, sign in again using the new user ID you created for your agent services account.",
+      "If you do not have one")
+
+      result should containLinkText("create a new user ID", routes.SignedOutController.redirectUserToCreateCleanCreds().url)
     }
   }
 

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/support/BaseISpec.scala
@@ -225,6 +225,23 @@ abstract class BaseISpec
     }
   }
 
+  protected def containLinkText(expectedMessageText: String, expectedHref: String): Matcher[Result] = {
+    import scala.collection.JavaConversions._
+    new Matcher[Result] {
+      override def apply(result: Result): MatchResult = {
+        val doc = Jsoup.parse(bodyOf(result))
+        val foundElements = doc.select(s"a[href=$expectedHref]")
+
+        val wasFoundWithCorrectMessage = foundElements.toList.exists(_.text() == expectedMessageText)
+        MatchResult(
+          wasFoundWithCorrectMessage,
+          s"""Response does not contain a link to "$expectedHref" with link text "$expectedMessageText" """,
+          s"""Response contains a link to "$expectedHref" with link text "$expectedMessageText" """
+        )
+      }
+    }
+  }
+
   protected def withMetricsTimerUpdate[A](expectedMetricName: String)(testCode: => A): Assertion = {
     givenCleanMetricRegistry()
     testCode


### PR DESCRIPTION
compressing redirect to create new creds into one record and changing content on sign-in-with-new-user-id page