### PR TITLE
[APB-4361][MP] Move trigger points to complete partial subscription

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessIdentificationController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessIdentificationController.scala
@@ -166,8 +166,7 @@ class BusinessIdentificationController @Inject()(
 
           subscriptionService.handlePartiallySubscribedAndRedirect(
             agent,
-            existingSession.utr.getOrElse(Utr("")),
-            existingSession.postcode.getOrElse(Postcode("")))(
+            existingSession)(
             whenNotPartiallySubscribed = createRecordAndRedirectToTasklist())
     }
 

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/PostcodeControllerWithOutAssuranceFlagISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/PostcodeControllerWithOutAssuranceFlagISpec.scala
@@ -74,7 +74,7 @@ class PostcodeControllerWithOutAssuranceFlagISpec extends BaseISpec with Session
       redirectLocation(result) shouldBe Some(routes.BusinessIdentificationController.showAlreadySubscribed().url)
     }
 
-    "showSubscriptionComplete for partially subscribed agent" in new TestSetupNoJourneyRecord{
+    "redirect to /national-insurance-number for partially subscribed agent" in new TestSetupNoJourneyRecord{
       withMatchingUtrAndPostcode(validUtr, validPostcode, isSubscribedToAgentServices = false, isSubscribedToETMP = true)
       partialSubscriptionWillSucceed(CompletePartialSubscriptionBody(validUtr, knownFacts = SubscriptionRequestKnownFacts(validPostcode)), arn = "TARN00023")
 
@@ -83,7 +83,7 @@ class PostcodeControllerWithOutAssuranceFlagISpec extends BaseISpec with Session
       sessionStoreService.currentSession.agentSession = Some(agentSession)
 
       val result = await(controller.submitPostcodeForm()(request))
-      redirectLocation(result) shouldBe Some(routes.SubscriptionController.showSubscriptionComplete().url)
+      redirectLocation(result) shouldBe Some(routes.NationalInsuranceController.showNationalInsuranceNumberForm().url)
     }
 
     "redirect to no match found when the subscription status is strange" in new TestSetupNoJourneyRecord {

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/StartControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/StartControllerISpec.scala
@@ -8,6 +8,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentType, _}
 import uk.gov.hmrc.agentsubscriptionfrontend.models.{AmlsDetails, _}
 import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AgentSubscriptionJourneyStub._
+import uk.gov.hmrc.agentsubscriptionfrontend.stubs.AgentSubscriptionStub.{partialSubscriptionWillSucceed, withMatchingUtrAndPostcode}
 import uk.gov.hmrc.agentsubscriptionfrontend.stubs.{AgentSubscriptionJourneyStub, AgentSubscriptionStub, AuthStub}
 import uk.gov.hmrc.agentsubscriptionfrontend.support.SampleUser.{individual, subscribingAgentEnrolledForNonMTD}
 import uk.gov.hmrc.agentsubscriptionfrontend.support.TestData._
@@ -166,29 +167,40 @@ class StartControllerISpec extends BaseISpec {
       }
     }
 
-    "returnAfterMapping" should {
+    "complete partial subscription and resirect to complete when the user comes back as partially subscribed" in new SetupUnsubscribed {
+      withMatchingUtrAndPostcode(validUtr, validPostcode, isSubscribedToAgentServices = false, isSubscribedToETMP = true)
+      partialSubscriptionWillSucceed(CompletePartialSubscriptionBody(validUtr, knownFacts = SubscriptionRequestKnownFacts(validPostcode)), arn = "TARN00023")
+      implicit val request = FakeRequest()
 
-      "given a valid subscription journey record" when {
+      val result = await(controller.returnAfterGGCredsCreated(id = Some(continueId.value))(request))
 
-        "redirect to the /task-list page and update journey record with mappingComplete as true" in {
-          implicit val request = authenticatedAs(subscribingAgentEnrolledForNonMTD)
-          givenSubscriptionJourneyRecordExists(id, record)
-          givenSubscriptionRecordCreated(record.authProviderId, record.copy(continueId = None, mappingComplete = true))
+      status(result) shouldBe 303
+      redirectLocation(result) shouldBe Some(routes.SubscriptionController.showSubscriptionComplete().url)
+    }
+  }
 
-          val result = await(controller.returnAfterMapping()(request))
+  "returnAfterMapping" should {
 
-          status(result) shouldBe 303
-          redirectLocation(result).head should include(routes.TaskListController.showTaskList().url)
-        }
+    "given a valid subscription journey record" when {
 
-        "throw a runtime exception when there is no record" in {
-          implicit val authenticatedRequest: FakeRequest[AnyContentAsEmpty.type] =
-            authenticatedAs(subscribingAgentEnrolledForNonMTD)
-          givenNoSubscriptionJourneyRecordExists(id)
-          intercept[RuntimeException] {
-            await(controller.returnAfterMapping()(authenticatedRequest))
-          }.getMessage shouldBe "Expected Journey Record missing"
-        }
+      "redirect to the /task-list page and update journey record with mappingComplete as true" in {
+        implicit val request = authenticatedAs(subscribingAgentEnrolledForNonMTD)
+        givenSubscriptionJourneyRecordExists(id, record)
+        givenSubscriptionRecordCreated(record.authProviderId, record.copy(continueId = None, mappingComplete = true))
+
+        val result = await(controller.returnAfterMapping()(request))
+
+        status(result) shouldBe 303
+        redirectLocation(result).head should include(routes.TaskListController.showTaskList().url)
+      }
+
+      "throw a runtime exception when there is no record" in {
+        implicit val authenticatedRequest: FakeRequest[AnyContentAsEmpty.type] =
+          authenticatedAs(subscribingAgentEnrolledForNonMTD)
+        givenNoSubscriptionJourneyRecordExists(id)
+        intercept[RuntimeException] {
+          await(controller.returnAfterMapping()(authenticatedRequest))
+        }.getMessage shouldBe "Expected Journey Record missing"
       }
     }
   }


### PR DESCRIPTION
move the completion of partial subscription after check answers instead of after postcode and enable ability to complete subscription after returning from creating a new user ID. This is related to the live issue in ticket APB-4361.