### PR TITLE
APB-5624 [CS] update email error content

### DIFF
--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -43,10 +43,10 @@ global.error.500.sa_helpline=os oes angen cymorth arnoch gyda’r cynllun Troi T
 
 ##Errors that override Play default messages
 error.maxLength =Ni ddylech nodi mwy na {0} o ffigurau
-error.email=Nodwch gyfeiriad e-bost dilys, megis eichenw@enghraifft.com
+error.email=Nodwch gyfeiriad e-bost yn y fformat cywir, megis enw@enghraifft.com
 
 ##Errors
-error.email.invalidchars=Rhaid i gyfeiriad e-bost y busnes gynnwys dim ond y llythrennau a i z, rhifau, atalnodau llawn, cysylltnodau, tanlinellau a’r symbol @
+error.email.invalidchars=Nodwch gyfeiriad e-bost yn y fformat cywir, megis enw@enghraifft.com
 error.email.maxlength=Rhaid i gyfeiriad e-bost y busnes fod yn 132 o gymeriadau neu lai
 error.postcode.invalid=Nodwch god post dilys, er enghraifft AA1 1AA
 error.postcode.invalidchars=Rhaid i’r cod post gynnwys dim ond y llythrennau a i z, rhifau a bylchau, megis AA1 1AA
@@ -131,10 +131,10 @@ error.contact-email-check.invalid=Dewiswch a hoffech ddefnyddio’r cyfeiriad e-
 contactEmailAddress.title=Beth yw’r cyfeiriad e-bost yr hoffech ei ddefnyddio ar gyfer eich cyfrif gwasanaethau asiant?
 contactEmailAddress.p=Byddwn yn ei ddefnyddio i roi gwybod i chi pan fo’ch cyfrif gwasanaethau asiant wedi’i greu, ac i roi gwybod i chi am statws ceisiadau am awdurdodiad.
 contactEmailAddress.button=Yn eich blaen
-error.contact-email.empty=Nodwch gyfeiriad e-bost
+error.contact-email.empty=Nodwch gyfeiriad e-bost, megis enw@enghraifft.com
 error.contact-email.maxLength=Mae’n rhaid i’r cyfeiriad e-bost gynnwys 132 o gymeriadau neu lai
 error.contact-email.missingSeparator=Nodwch gyfeiriad e-bost yn y fformat cywir, megis enw@enghraifft.com
-error.contact-email.invalidChar=Mae’n rhaid i’r cyfeiriad e-bost gynnwys y llythrennau a i z, rhifau, atalnodau llawn, cysylltnodau, tanlinellau a’r symbol @ yn unig
+error.contact-email.invalidChar=Nodwch gyfeiriad e-bost yn y fformat cywir, megis enw@enghraifft.com
 
 #Contact Trading Name Check
 contactTradingNameCheck.title=Ai dyma’r enw yr hoffech ei ddangos i’ch cleientiaid?

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -48,6 +48,7 @@ error.email=Nodwch gyfeiriad e-bost yn y fformat cywir, megis enw@enghraifft.com
 ##Errors
 error.email.invalidchars=Nodwch gyfeiriad e-bost yn y fformat cywir, megis enw@enghraifft.com
 error.email.maxlength=Rhaid i gyfeiriad e-bost y busnes fod yn 132 o gymeriadau neu lai
+error.business-email.empty=Nodwch gyfeiriad e-bost eich busnes, megis enw@enghraifft.com
 error.postcode.invalid=Nodwch god post dilys, er enghraifft AA1 1AA
 error.postcode.invalidchars=Rhaid i’r cod post gynnwys dim ond y llythrennau a i z, rhifau a bylchau, megis AA1 1AA
 error.postcode.blacklisted=Ni allwch ddefnyddio’r cod post a nodwyd gennych
@@ -82,7 +83,6 @@ error.crn.invalid=Rhaid i’r rhif cofrestru cwmni fod yn 8 rhif, neu’n 2 lyth
 error.business-name.empty =Nodwch enw eich busnes
 error.business-name.invalid = Nodwch enw eich busnes yn y fformat cywir
 error.business-name.maxlength =Rhaid i enw’r busnes fod yn 40 o gymeriadau neu lai
-error.business-email.empty=Nodwch gyfeiriad e-bost eich busnes
 error.confirm-business-value.invalid=Dewiswch ‘Iawn’ os mai’ch busnes chi yw hwn
 error.summary.heading=Mae problem wedi codi
 error.prefix=Gwall:

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -48,6 +48,7 @@ error.email= Enter an email address in the correct format, like name@example.com
 ##Errors
 error.email.invalidchars=Enter a email address in the correct format, like name@example.com
 error.email.maxlength=Business email address must be 132 characters or less
+error.business-email.empty=Enter your business email address, like name@example.com
 error.postcode.invalid=Enter a valid postcode, for example AA1 1AA
 error.postcode.invalidchars=Postcode must only include letters a to z, numbers and spaces, like AA1 1AA
 error.postcode.blacklisted=You can’t use the postcode you’ve entered
@@ -82,7 +83,6 @@ error.crn.invalid=Company registration number must be 8 numbers, or 2 letters fo
 error.business-name.empty = Enter your business name
 error.business-name.invalid = Enter your business name in the correct format
 error.business-name.maxlength = Business name must be 40 characters or less
-error.business-email.empty=Enter your business email address
 error.confirm-business-value.invalid=Select yes if this is your business
 error.summary.heading=There is a problem
 error.prefix=Error:

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -46,7 +46,7 @@ error.maxLength = You must not enter more than {0} figures
 error.email= Enter an email address in the correct format, like name@example.com
 
 ##Errors
-error.email.invalidchars=Enter a email address in the correct format, like name@example.com
+error.email.invalidchars=Enter an email address in the correct format, like name@example.com
 error.email.maxlength=Business email address must be 132 characters or less
 error.business-email.empty=Enter your business email address, like name@example.com
 error.postcode.invalid=Enter a valid postcode, for example AA1 1AA

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -43,10 +43,10 @@ global.error.500.sa_helpline=if you need help with Making Tax Digital for Income
 
 ##Errors that override Play default messages.en
 error.maxLength = You must not enter more than {0} figures
-error.email= Enter a valid email address, like yourname@example.com
+error.email= Enter an email address in the correct format, like name@example.com
 
 ##Errors
-error.email.invalidchars=Business email address must only contain letters a to z, numbers, full stops, hyphens, underscores and @ signs
+error.email.invalidchars=Enter a email address in the correct format, like name@example.com
 error.email.maxlength=Business email address must be 132 characters or less
 error.postcode.invalid=Enter a valid postcode, for example AA1 1AA
 error.postcode.invalidchars=Postcode must only include letters a to z, numbers and spaces, like AA1 1AA
@@ -131,10 +131,10 @@ error.contact-email-check.invalid=Select if you want to use the email address di
 contactEmailAddress.title=What is the email address you want to use for your agent services account?
 contactEmailAddress.p=We will use it to tell you when your agent services account has been created and to let you know the status of authorisation requests.
 contactEmailAddress.button=Continue
-error.contact-email.empty=Enter an email address
+error.contact-email.empty=Enter an email address, like name@example.com
 error.contact-email.maxLength=Email address must be 132 characters or fewer
 error.contact-email.missingSeparator=Enter an email address in the correct format, like name@example.com
-error.contact-email.invalidChar=Email address must only contain letters a to z, numbers, full stops, hyphens, underscores and @ signs
+error.contact-email.invalidChar=Enter an email address in the correct format, like name@example.com
 
 #Contact Trading Name Check
 contactTradingNameCheck.title=Is this the name you want to show to your clients?


### PR DESCRIPTION
I want to clean up the message keys but it'll require a bit of extra work in `Common Validators.scala` (will raise a separate PR)

```
private def validEmailAddress(
    nonEmptyMessageKey: String = "error.business-email.empty",
    maxLengthMessageKey: String = "error.email.maxlength",
    invalidCharMessageKey: String = "error.email.invalidchars",
    missingEmailPartSeperatorMessageKey: String = "error.email.invalidchars") = Constraint { fieldValue: String =>
    nonEmptyWithMessage(nonEmptyMessageKey)(fieldValue) match {
      case i: Invalid => i
      case Valid => {
        if (fieldValue.size > EmailMaxLength) {
          Invalid(ValidationError(maxLengthMessageKey))
        } else if (fieldValue.contains('@')) {
          val email = fieldValue.split('@')
          if (!email(0).matches(EmailLocalPartRegex) || !email(1).matches(EmailDomainRegex)) {
            Invalid(ValidationError(invalidCharMessageKey))
          } else Constraints.emailAddress(fieldValue)
        } else
          Invalid(ValidationError(missingEmailPartSeperatorMessageKey))
      }
    }
  }
```

`invalidCharMessageKey` and`missingEmailPartSeperatorMessageKey` should really just be something like "wrongFormatKey" since those two keys are the same message for business email and contact email...