### PR TITLE
APB-6577 Prevent user from registering if NINO is marked as deceased

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessIdentificationController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/BusinessIdentificationController.scala
@@ -71,7 +71,8 @@ class BusinessIdentificationController @Inject()(
                                                   businessNameTemplate: business_name,
                                                   alreadySubscribedTemplate: already_subscribed,
                                                   updateBusinessAddressTemplate: update_business_address,
-                                                  postcodeNotAllowedTemplate: postcode_not_allowed)(
+                                                  postcodeNotAllowedTemplate: postcode_not_allowed,
+                                                  cannotVerifyIdentity: cannot_verify_identity)(
   implicit val appConfig: AppConfig,
   val ec: ExecutionContext)
     extends FrontendController(mcc) with AuthActions
@@ -443,6 +444,12 @@ class BusinessIdentificationController @Inject()(
   def showExistingJourneyFound: Action[AnyContent] = Action.async { implicit request =>
     withSubscribingAgent { _ =>
       Ok(existingJourneyFoundTemplate())
+    }
+  }
+
+  def showCannotConfirmIdentity: Action[AnyContent] = Action.async { implicit request =>
+    withSubscribingAgent { _ =>
+      Ok(cannotVerifyIdentity(displayAgentHelplineLink = false))
     }
   }
 

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/models/DesignatoryDetails.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/models/DesignatoryDetails.scala
@@ -23,7 +23,7 @@ case class DesignatoryDetails(person: Option[Person] = None)
 
 object DesignatoryDetails {
 
-  case class Person(lastName: Option[String] = None, dateOfBirth: Option[DateOfBirth] = None)
+  case class Person(lastName: Option[String] = None, dateOfBirth: Option[DateOfBirth] = None, deceased: Option[Boolean] = None)
 
   object Person {
     implicit val format: Format[Person] = Json.format[Person]

--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/views/cannot_verify_identity.scala.html
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/views/cannot_verify_identity.scala.html
@@ -1,0 +1,36 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.agentsubscriptionfrontend.controllers.routes
+@import uk.gov.hmrc.agentsubscriptionfrontend.config.AppConfig
+
+
+@this(mainTemplate: MainTemplate)
+
+@(displayAgentHelplineLink: Boolean)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
+
+@mainTemplate(title = msgs("cannotVerifyIdentity.title")) {
+
+    <h1 class="govuk-heading-xl">@msgs("cannotVerifyIdentity.title")</h1>
+    @if(displayAgentHelplineLink) {
+        <p>@Html(msgs("cannotVerifyIdentity.p1.agentHelplineVersion"))</p>
+    } else {
+        <p>@Html(msgs("cannotVerifyIdentity.p1.contactHmrcVersion"))</p>
+    }
+    <p>@msgs("cannotVerifyIdentity.p2")</p>
+    <p><a class="govuk-button" href="@routes.BusinessTypeController.showBusinessTypeForm">@msgs("cannotVerifyIdentity.a")</a></p>
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -42,6 +42,7 @@ POST        /vat-registration-details                      uk.gov.hmrc.agentsubs
 
 GET         /no-match                                      uk.gov.hmrc.agentsubscriptionfrontend.controllers.BusinessIdentificationController.showNoMatchFound()
 GET         /company-not-allowed                           uk.gov.hmrc.agentsubscriptionfrontend.controllers.BusinessIdentificationController.showCompanyNotAllowed()
+GET         /cannot-confirm-identity                       uk.gov.hmrc.agentsubscriptionfrontend.controllers.BusinessIdentificationController.showCannotConfirmIdentity()
 
 GET         /confirm-business                              uk.gov.hmrc.agentsubscriptionfrontend.controllers.BusinessIdentificationController.showConfirmBusinessForm()
 POST        /confirm-business                              uk.gov.hmrc.agentsubscriptionfrontend.controllers.BusinessIdentificationController.submitConfirmBusinessForm()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -410,6 +410,12 @@ button.back=Back
 link.finishSignOut=Finish and sign out
 button.signIn=Sign in
 
+#Cannot verify identity (Agent helpline version)
+cannotVerifyIdentity.title=We could not confirm your identity
+cannotVerifyIdentity.p1.agentHelplineVersion=We need more information to confirm your identity. Contact HMRC using the details on <a href="https://www.gov.uk/guidance/dedicated-helplines-and-contacts-for-authorised-agents" target="_blank" rel="noopener noreferrer">Dedicated helplines and contacts for Tax Agents</a>.
+cannotVerifyIdentity.p1.contactHmrcVersion=We need more information to confirm your identity. Get in touch using the details on <a href="https://www.gov.uk/contact-hmrc" target="_blank" rel="noopener noreferrer">Contact HMRC</a>.
+cannotVerifyIdentity.p2=If you’ve entered the incorrect details, you can try again.
+cannotVerifyIdentity.a=Try again
 #Setup Incomplete
 setupIncomplete.title=We could not confirm your identity
 setupIncomplete.p1=Before you can create an agent services account, we need to be sure that a client has authorised you to deal with HMRC.

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/connectors/AgentSubscriptionConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/connectors/AgentSubscriptionConnectorISpec.scala
@@ -348,7 +348,7 @@ class AgentSubscriptionConnectorISpec extends BaseISpec with MetricTestSupport {
 
     "return DesignatoryDetails if found for a given nino" in {
       AgentSubscriptionStub.givenDesignatoryDetailsForNino(nino, Some(lastName), dob)
-      await(connector.getDesignatoryDetails(nino)) shouldBe DesignatoryDetails(Some(Person(Some(lastName), Some(dob))))
+      await(connector.getDesignatoryDetails(nino)) shouldBe DesignatoryDetails(Some(Person(Some(lastName), Some(dob), deceased = Some(false))))
     }
 
     "handle the case when DesignatoryDetails are not found for a given nino" in {

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/NationalInsuranceControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/controllers/NationalInsuranceControllerISpec.scala
@@ -152,6 +152,19 @@ class NationalInsuranceControllerISpec extends BaseISpec with SessionDataMissing
 
       }
 
+      "redirect to /no-match-found page if nino is marked as deceased in citizen details" in new TestSetupNoJourneyRecord {
+        AgentSubscriptionStub.givenDesignatoryDetailsForNino(Nino("AE123456C"), Some("Matchmaker"), DateOfBirth(LocalDate.now()), deceased = true)
+        implicit val request = authenticatedAs(subscribingAgentEnrolledForNonMTD.copy(nino = Some("AE123456C")), POST).withFormUrlEncodedBody("nino" -> "AE123456C")
+        sessionStoreService.currentSession.agentSession = Some(agentSession)
+
+        val result = await(controller.submitNationalInsuranceNumberForm()(request))
+
+        status(result) shouldBe 303
+
+        redirectLocation(result) shouldBe Some(routes.BusinessIdentificationController.showNoMatchFound().url)
+
+      }
+
       "redirect to /date-of-birth if nino from auth and nino from user input do not match " +
         "and businessType is LLP (although we do not expect a auth nino for LLP)" in new TestSetupNoJourneyRecord {
         AgentSubscriptionStub.givenDesignatoryDetailsForNino(Nino("AE123456D"), Some("Matchmaker"), DateOfBirth(LocalDate.now()))

--- a/it/uk/gov/hmrc/agentsubscriptionfrontend/stubs/AgentSubscriptionStub.scala
+++ b/it/uk/gov/hmrc/agentsubscriptionfrontend/stubs/AgentSubscriptionStub.scala
@@ -233,7 +233,7 @@ object AgentSubscriptionStub {
         .willReturn(aResponse()
           .withStatus(500)))
 
-  def givenDesignatoryDetailsForNino(nino: Nino, lastName: Option[String], dob: DateOfBirth): StubMapping =
+  def givenDesignatoryDetailsForNino(nino: Nino, lastName: Option[String], dob: DateOfBirth, deceased: Boolean = false): StubMapping =
     stubFor(
       get(
         urlEqualTo(
@@ -251,7 +251,7 @@ object AgentSubscriptionStub {
                        |         "sex" : "M",
                        |         "dateOfBirth" : "${dob.value.toString}",
                        |         "nino" : "TW189213B",
-                       |         "deceased" : false
+                       |         "deceased" : $deceased
                        |       },
                        |       "address" : {
                        |         "line1" : "26 FARADAY DRIVE",


### PR DESCRIPTION
See APB-6577.
Currently there are two proposed versions of the new content.
Both are implemented, you can switch between the two of them through a boolean flag (BusinessIdentificationController.scala, line 452).
Once there is a decision on which version to use, please set the flag appropriately and merge.
