### PR TITLE
APB-7670 Fixed bug with AMLS date form error

### DIFF
--- a/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/AMLSController.scala
+++ b/app/uk/gov/hmrc/agentsubscriptionfrontend/controllers/AMLSController.scala
@@ -291,15 +291,13 @@ class AMLSController @Inject() (
       agent.getMandatoryAmlsData.amlsDetails.flatMap(_.membershipExpiresOn) match {
         case Some(expiry) =>
           val formData = Map(
-            "amlsCode"     -> hmrcAmlsCode,
             "expiry.day"   -> expiry.getDayOfMonth.toString,
             "expiry.month" -> expiry.getMonthValue.toString,
             "expiry.year"  -> expiry.getYear.toString
           )
           Ok(amlsEnterRenewalDate(enterAmlsExpiryDateForm.bind(formData)))
         case None =>
-          val formData = Map("amlsCode" -> hmrcAmlsCode)
-          Ok(amlsEnterRenewalDate(enterAmlsExpiryDateForm.bind(formData)))
+          Ok(amlsEnterRenewalDate(enterAmlsExpiryDateForm))
       }
     }
   }


### PR DESCRIPTION
Seems the issue was caused by the controller attempting to bind a field `amlsCode` to a form, but the form does not have that field.