### PR TITLE
APB-10672 Time‑bound messaging for saved ASA subscription progress

### DIFF
--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -229,9 +229,9 @@ task-list.not-started=HEB DDECHRAU
 task-list.cannot-start-yet=METHU DECHRAU ETO
 
 #Saved Progress
-saved-progress.title=Cedwir eich cynnydd am 30 diwrnod
+saved-progress.title=Mae eich cynnydd wedi’i gadw tan 17 Mai 2026.
 saved-progress.p1=Yr hyn y mae angen i chi ei wneud nesaf
-saved-progress.p2=Mae’n rhaid i chi ddod yn ôl a chwblhau’r ffurflen hon cyn pen 30 diwrnod.
+saved-progress.p2=Mae’n rhaid i chi ddychwelyd a chwblhau’r ffurflen hon erbyn 17 Mai 2026.
 saved-progress.p3=I gwblhau’r ffurflen hon yn nes ymlaen, ewch i’r {0} ar GOV.UK a mewngofnodi i’r gwasanaeth hwn eto.
 saved-progress.link=tudalen arweiniad ynglŷn â chreu cyfrif gwasanaethau asiant (yn agor ffenestr neu dab newydd)
 saved-progress.p4=Bydd angen i chi fewngofnodi gyda’r un Dynodydd Defnyddiwr (ID) ar gyfer Porth y Llywodraeth a ddefnyddioch wrth ddechrau llenwi’r ffurflen hon.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -229,9 +229,9 @@ task-list.not-started=Not started
 task-list.cannot-start-yet=Cannot start yet
 
 #Saved Progress
-saved-progress.title=Your progress has been saved for 30 days
+saved-progress.title=Your details will be saved until 17 May 2026
 saved-progress.p1=What you need to do next
-saved-progress.p2=You need to come back and complete this form within 30 days.
+saved-progress.p2=You must come back and complete this form by 17 May 2026.
 saved-progress.p3=To complete this form later, go to the {0} on GOV.UK and sign in to this service again.
 saved-progress.link=guidance page about creating an agent services account (opens in a new tab)
 saved-progress.p4=You will need to sign in with the same Government Gateway user ID you used when you started filling out this form.

--- a/it/test/uk/gov/hmrc/agentsubscriptionfrontend/controllers/TaskListControllerISpecIt.scala
+++ b/it/test/uk/gov/hmrc/agentsubscriptionfrontend/controllers/TaskListControllerISpecIt.scala
@@ -265,10 +265,10 @@ class TaskListControllerISpecIt extends BaseISpecIt with EmailVerificationBehavi
       status(result) shouldBe 200
 
       val html = Jsoup.parse(Helpers.contentAsString(Future.successful(result)))
-      html.title() shouldBe "Your progress has been saved for 30 days - Create an agent services account - GOV.UK"
+      html.title() shouldBe "Your details will be saved until 17 May 2026 - Create an agent services account - GOV.UK"
       html.select(Css.H2).text() shouldBe "What you need to do next"
       val paragraphs = html.select(Css.paragraphs)
-      paragraphs.get(0).text() shouldBe "You need to come back and complete this form within 30 days."
+      paragraphs.get(0).text() shouldBe "You must come back and complete this form by 17 May 2026."
       paragraphs.get(1).text() shouldBe "To complete this form later, go to the guidance page about " +
         "creating an agent services account (opens in a new tab) on GOV.UK and sign in to this service again."
       paragraphs


### PR DESCRIPTION
Make messaging shown on the subscription task list clearer relating to saved progress must clearly state that the application must be completed by 17 May 2026 & confirmation messaging stating that the application must be completed by 17 May 2026.